### PR TITLE
Deduplicate type labels and dynamic affecting years

### DIFF
--- a/lgu2/templates/changes/form.html
+++ b/lgu2/templates/changes/form.html
@@ -83,58 +83,16 @@
                 <div class="from"><label for="affecting-start-year">From:</label><select
                         name="affecting-start-year" id="affecting-start-year">
                         <option value="" selected="selected">YYYY</option>
-                        <option value="2002">2002</option>
-                        <option value="2003">2003</option>
-                        <option value="2004">2004</option>
-                        <option value="2005">2005</option>
-                        <option value="2006">2006</option>
-                        <option value="2007">2007</option>
-                        <option value="2008">2008</option>
-                        <option value="2009">2009</option>
-                        <option value="2010">2010</option>
-                        <option value="2011">2011</option>
-                        <option value="2012">2012</option>
-                        <option value="2013">2013</option>
-                        <option value="2014">2014</option>
-                        <option value="2015">2015</option>
-                        <option value="2016">2016</option>
-                        <option value="2017">2017</option>
-                        <option value="2018">2018</option>
-                        <option value="2019">2019</option>
-                        <option value="2020">2020</option>
-                        <option value="2021">2021</option>
-                        <option value="2022">2022</option>
-                        <option value="2023">2023</option>
-                        <option value="2024">2024</option>
-                        <option value="2025">2025</option>
+                        {% for year in affecting_years %}
+                        <option value="{{ year }}">{{ year }}</option>
+                        {% endfor %}
                     </select></div>
                 <div class="to"><label for="affecting-end-year">To:</label><select
                         name="affecting-end-year" id="affecting-end-year">
                         <option selected="selected">YYYY</option>
-                        <option value="2002">2002</option>
-                        <option value="2003">2003</option>
-                        <option value="2004">2004</option>
-                        <option value="2005">2005</option>
-                        <option value="2006">2006</option>
-                        <option value="2007">2007</option>
-                        <option value="2008">2008</option>
-                        <option value="2009">2009</option>
-                        <option value="2010">2010</option>
-                        <option value="2011">2011</option>
-                        <option value="2012">2012</option>
-                        <option value="2013">2013</option>
-                        <option value="2014">2014</option>
-                        <option value="2015">2015</option>
-                        <option value="2016">2016</option>
-                        <option value="2017">2017</option>
-                        <option value="2018">2018</option>
-                        <option value="2019">2019</option>
-                        <option value="2020">2020</option>
-                        <option value="2021">2021</option>
-                        <option value="2022">2022</option>
-                        <option value="2023">2023</option>
-                        <option value="2024">2024</option>
-                        <option value="2025">2025</option>
+                        {% for year in affecting_years %}
+                        <option value="{{ year }}">{{ year }}</option>
+                        {% endfor %}
                     </select></div>
             </div>
         </div>

--- a/lgu2/views/changes/types.py
+++ b/lgu2/views/changes/types.py
@@ -1,27 +1,14 @@
-TYPES = {
-    'ukpga': "UK Public General Acts",
-    'ukla': "UK Local Acts",
-    'apgb': "Acts of the Parliament of Great Britain",
-    'aep': "Acts of the English Parliament",
-    'aosp': "Acts of the Old Scottish Parliament",
-    'asp': "Acts of the Scottish Parliament",
-    'aip': "Acts of the Old Irish Parliament",
-    'apni': "Acts of the Northern Ireland Parliament",
-    'mnia': "Measures of the Northern Ireland Assembly",
-    'nia': "Acts of the Northern Ireland Assembly",
-    'ukcm': "Church Measures",
-    'asc': "Acts of Senedd Cymru",
-    'anaw': "Acts of the National Assembly for Wales",
-    'mwa': "Measures of the National Assembly for Wales",
-    'uksi': "UK Statutory Instruments",
-    'ssi': "Scottish Statutory Instruments",
-    'wsi': "Wales Statutory Instruments",
-    'nisr': "Northern Ireland Statutory Rules",
-    'nisi': "Northern Ireland Orders in Council",
-    'nisro': "Northern Ireland Statutory Rules and Orders",
-    'eur': "Regulations originating from the EU",
-    'eudn': "Decisions originating from the EU",
-    'eudr': "Directives originating from the EU",
-}
+from datetime import datetime
 
-AFFECTING_YEARS = range(2002, 2026)
+from lgu2.util.labels import labels
+
+TYPES_CODES = [
+    'ukpga', 'ukla', 'apgb', 'aep', 'aosp', 'asp', 'aip', 'apni',
+    'mnia', 'nia', 'ukcm', 'asc', 'anaw', 'mwa',
+    'uksi', 'ssi', 'wsi', 'nisr', 'nisi', 'nisro',
+    'eur', 'eudn', 'eudr',
+]
+
+TYPES = {code: labels[code]['plural'] for code in TYPES_CODES}
+
+AFFECTING_YEARS = range(2002, datetime.now().year + 1)


### PR DESCRIPTION
## Summary
- Build `TYPES` dict from `util/labels` instead of hardcoding duplicate label strings, preparing for future localisation
- Make `AFFECTING_YEARS` dynamic based on current year (was hardcoded to 2025)
- Replace hardcoded year options in the changes form range selectors with the same `affecting_years` template variable

## Test plan
- [ ] Verify changes intro page renders type dropdowns correctly
- [ ] Verify changes results page renders type and year dropdowns correctly
- [ ] Verify "Range of years" selectors include the current year