### PR TITLE
Redirect subprovision URLs to parent section with anchor

### DIFF
--- a/lgu2/api/fragment.py
+++ b/lgu2/api/fragment.py
@@ -92,3 +92,8 @@ def get_akn(type: str, year, number, section: str, version: Optional[str] = None
     url = _make_url(type, year, number, section, version)
     response = server.get_akn(url, language)
     return package_xml(response)
+
+
+def head(type: str, year, number, section: str, version: Optional[str] = None, language: Optional[str] = None) -> int:  # HTTP status code
+    url = _make_url(type, year, number, section, version)
+    return server.head(url, language).status_code

--- a/lgu2/api/server.py
+++ b/lgu2/api/server.py
@@ -27,6 +27,15 @@ def get(endpoint: str, accept: str, language: Optional[str] = None) -> requests.
     return requests.get(url, headers=headers)
 
 
+def head(endpoint: str, language: Optional[str] = None) -> requests.Response:
+    url = SERVER + endpoint
+    headers = {}
+    language = fix_language(language)
+    if language is not None:
+        headers['Accept-Language'] = language
+    return requests.head(url, headers=headers)
+
+
 def get_json(endpoint: str, language: Optional[str] = None) -> Any:
     return get(endpoint, 'application/json', language).json()
 

--- a/lgu2/tests/test_subprovision_redirect.py
+++ b/lgu2/tests/test_subprovision_redirect.py
@@ -1,0 +1,189 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from django.urls import resolve, reverse
+
+from lgu2.views import fragment
+
+
+class SubprovisionRedirectTests(SimpleTestCase):
+
+    def test_subprovision_data_urls_resolve_to_fragment_data_view(self):
+        cases = [
+            ('/ukpga/2024/1/section/1-2/data.json', 'fragment-data', {}),
+            ('/ukpga/2024/1/section/1-2/2025-01-01/data.json', 'fragment-version-data',
+             {'version': '2025-01-01'}),
+            ('/ukpga/2024/1/section/1-2/english/data.json', 'fragment-lang-data',
+             {'lang': 'english'}),
+            ('/ukpga/2024/1/section/1-2/2025-01-01/english/data.json', 'fragment-version-lang-data',
+             {'version': '2025-01-01', 'lang': 'english'}),
+        ]
+
+        for path, url_name, extra_kwargs in cases:
+            with self.subTest(path=path):
+                match = resolve(path)
+
+                self.assertEqual(match.func, fragment.data)
+                self.assertEqual(match.url_name, url_name)
+                self.assertEqual(match.kwargs['section'], 'section/1-2')
+                self.assertEqual(match.kwargs['format'], 'json')
+                for key, value in extra_kwargs.items():
+                    self.assertEqual(match.kwargs[key], value)
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_section_subprovision_redirects_to_parent_with_anchor(self, mock_get, mock_head):
+        mock_head.return_value = 200
+
+        response = self.client.get(reverse('fragment', args=['ukpga', 2024, 1, 'section/1-2']))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            reverse('fragment', args=['ukpga', 2024, 1, 'section/1']) + '#section-1-2',
+        )
+        mock_get.assert_not_called()
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_multi_level_subprovision_keeps_hyphenated_tail_in_anchor(self, mock_get, mock_head):
+        mock_head.return_value = 200
+
+        response = self.client.get(reverse('fragment', args=['ukpga', 2024, 1, 'section/1-2-a-i']))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            reverse('fragment', args=['ukpga', 2024, 1, 'section/1']) + '#section-1-2-a-i',
+        )
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_nested_schedule_paragraph_subprovision(self, mock_get, mock_head):
+        mock_head.return_value = 200
+
+        response = self.client.get(reverse(
+            'fragment', args=['ukpga', 2024, 1, 'schedule/1/paragraph/3-1']))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            reverse('fragment', args=['ukpga', 2024, 1, 'schedule/1/paragraph/3'])
+            + '#schedule-1-paragraph-3-1',
+        )
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_article_kind_with_letter_in_parent(self, mock_get, mock_head):
+        mock_head.return_value = 200
+
+        response = self.client.get(reverse('fragment', args=['uksi', 2024, 1, 'article/1A-3']))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            reverse('fragment', args=['uksi', 2024, 1, 'article/1A']) + '#article-1A-3',
+        )
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_preserves_version_segment(self, mock_get, mock_head):
+        mock_head.return_value = 200
+
+        response = self.client.get(reverse(
+            'fragment-version', args=['ukpga', 2024, 1, 'section/1-2', '2025-01-01']))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            reverse('fragment-version', args=['ukpga', 2024, 1, 'section/1', '2025-01-01']) + '#section-1-2',
+        )
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_preserves_language_segment(self, mock_get, mock_head):
+        mock_head.return_value = 200
+
+        response = self.client.get(reverse(
+            'fragment-lang', args=['ukpga', 2024, 1, 'section/1-2', 'english']))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            reverse('fragment-lang', args=['ukpga', 2024, 1, 'section/1', 'english']) + '#section-1-2',
+        )
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_preserves_version_and_language(self, mock_get, mock_head):
+        mock_head.return_value = 200
+
+        response = self.client.get(reverse(
+            'fragment-version-lang',
+            args=['ukpga', 2024, 1, 'section/1-2', '2025-01-01', 'english']))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            reverse('fragment-version-lang',
+                    args=['ukpga', 2024, 1, 'section/1', '2025-01-01', 'english']) + '#section-1-2',
+        )
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_head_404_returns_404(self, mock_get, mock_head):
+        mock_head.return_value = 404
+
+        response = self.client.get(reverse('fragment', args=['ukpga', 2024, 1, 'section/1-999']))
+
+        self.assertEqual(response.status_code, 404)
+        mock_get.assert_not_called()
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_non_subprovision_shape_falls_through(self, mock_get, mock_head):
+        # section/1 has no hyphen → normal fragment request
+        mock_get.return_value = {'error': 'ignored', 'meta': {}}
+
+        self.client.get(reverse('fragment', args=['ukpga', 2024, 1, 'section/1']))
+
+        mock_head.assert_not_called()
+        mock_get.assert_called_once()
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_crossheading_with_hyphenated_title_is_excluded(self, mock_get, mock_head):
+        # section/1/crossheading/something-or-other: 'crossheading' is not in
+        # _SUBPROVISION_KINDS, so _split_subprovision returns None immediately.
+        mock_get.return_value = {'error': 'ignored', 'meta': {}}
+
+        self.client.get(reverse(
+            'fragment', args=['ukpga', 2024, 1, 'section/1/crossheading/something-or-other']))
+
+        mock_head.assert_not_called()
+        mock_get.assert_called_once()
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_head_non_200_non_404_falls_through(self, mock_get, mock_head):
+        # A 500 (or any other status) should not short-circuit; the main view
+        # will make its own call to the API and handle the error itself.
+        mock_head.return_value = 500
+        mock_get.return_value = {'error': 'ignored', 'meta': {}}
+
+        response = self.client.get(reverse('fragment', args=['ukpga', 2024, 1, 'section/1-2']))
+
+        self.assertEqual(response.status_code, 404)  # view falls through to normal handling; 404 here is from the stub API response, not the redirect logic
+        mock_head.assert_called_once()
+        mock_get.assert_called_once()
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_each_subprovision_kind_is_detected(self, mock_get, mock_head):
+        mock_head.return_value = 200
+
+        for kind in ('section', 'article', 'paragraph', 'rule', 'regulation'):
+            with self.subTest(kind=kind):
+                response = self.client.get(reverse('fragment', args=['ukpga', 2024, 1, f'{kind}/1-2']))
+                self.assertEqual(response.status_code, 302)
+                self.assertTrue(response['Location'].endswith(f'#{kind}-1-2'))

--- a/lgu2/urls.py
+++ b/lgu2/urls.py
@@ -149,8 +149,8 @@ urlpatterns += i18n_patterns(
     re_path(fr'^{TYPE}/{YEAR}/{NUMBER}/{SECTION}/{LANG}/{DATA}$', fragment.data, name='fragment-lang-data'),
     re_path(fr'^{TYPE}/{YEAR}/{NUMBER}/{SECTION}/{VERSION}$', fragment.fragment, name='fragment-version'),
     re_path(fr'^{TYPE}/{YEAR}/{NUMBER}/{SECTION}/{VERSION}/{DATA}$', fragment.data, name='fragment-version-data'),
-    re_path(fr'^{TYPE}/{YEAR}/{NUMBER}/{SECTION}$', fragment.fragment, name='fragment'),
     re_path(fr'^{TYPE}/{YEAR}/{NUMBER}/{SECTION}/{DATA}$', fragment.data, name='fragment-data'),
+    re_path(fr'^{TYPE}/{YEAR}/{NUMBER}/{SECTION}$', fragment.fragment, name='fragment'),
 
 
     # changes Intro

--- a/lgu2/views/fragment.py
+++ b/lgu2/views/fragment.py
@@ -18,7 +18,50 @@ from ..util.breadcrumbs import make_breadcrumbs, LEGISLATION_BREADCRUMB_HEADING
 from ..util.redirects import should_redirect
 
 
+# Derived from the legacy Orbeon pipeline (legislation.xpl:206), which 404s URLs
+# whose section path ends in {kind}/{parent}-{tail}. We detect the same shape by
+# inspecting the last two path segments rather than the Orbeon substring regex,
+# so that nested paths like schedule/1/paragraph/3-1 produce the correct parent
+# URL and anchor.
+_SUBPROVISION_KINDS = ('section', 'article', 'paragraph', 'rule', 'regulation')
+
+
+def _split_subprovision(section: str):
+    segments = section.split('/')
+    if len(segments) < 2 or segments[-2] not in _SUBPROVISION_KINDS:
+        return None
+    parent_num, sep, tail = segments[-1].partition('-')
+    if not sep or not parent_num or not tail:
+        return None
+    parent_segments = segments[:-1] + [parent_num]
+    parent_section = '/'.join(parent_segments)
+    anchor = '-'.join(parent_segments + [tail])
+    return parent_section, anchor
+
+
+def _subprovision_redirect(request, type: str, year: str, number: str, section: str,
+                           version: Optional[str], lang: Optional[str]):
+    split = _split_subprovision(section)
+    if split is None:
+        return None
+    parent_section, anchor = split
+
+    status = api.head(type, year, number, section, version, lang)
+    if status == 404:
+        template = loader.get_template('404.html')
+        return HttpResponseNotFound(template.render({}, request))
+    if status != 200:
+        return None
+
+    path = make_fragment_link(type, year, number, parent_section, version, lang)
+    return HttpResponseRedirect(f'{path}#{anchor}')
+
+
 def fragment(request, type: str, year: str, number: str, section: str, version: Optional[str] = None, lang: Optional[str] = None):
+
+    redirect = _subprovision_redirect(request, type, year, number, section, version, lang)
+    if redirect is not None:
+        return redirect
 
     data = api.get(type, year, number, section, version, lang)
     # API should add None values to fragment requests


### PR DESCRIPTION
## Background

In UK legislation, a section like `section/1` is an independently addressable fragment. Subsections — identified by a hyphenated ID like `section/1-2` — are not: they live within the body of their parent section and are reachable via an anchor link.

The legacy Orbeon pipeline handled this by returning 404 for any URL whose section path ended in `{kind}/{parent}-{tail}`. This replacement replicates the correct user-facing behaviour: rather than a 404, the user is redirected to the parent section with a fragment anchor, so e.g. `/ukpga/2024/1/section/1-2` → `/ukpga/2024/1/section/1#section-1-2`.

## What this PR does

- Detects the subprovision URL shape by inspecting the last two path segments: the second-to-last must be a known provision kind (`section`, `article`, `paragraph`, `rule`, `regulation`) and the last must contain a hyphen.
- Makes a HEAD request to the API to confirm the document exists. A 404 from the API is returned to the user as a 404; any other non-200 status falls through to normal handling.
- On a 200, issues a 302 redirect to the parent provision URL with a `#{kind}-{id}` anchor appended.
- Works correctly for nested paths (`schedule/1/paragraph/3-1` → `schedule/1/paragraph/3#schedule-1-paragraph-3-1`) and for all URL variants (versioned, language-specific, or both).
- Data URLs (`.../data.json` etc.) are not affected by this logic.

## Test coverage

13 tests covering: URL resolution for data variants, the redirect happy path, multi-level hyphenated IDs, nested provision paths, alphanumeric parent IDs, all four URL parameter combinations (version/lang/both/neither), HEAD 404 passthrough, non-subprovision shapes, crossheading paths, and non-200/non-404 HEAD responses.