### PR TITLE
changes all the labels mentioned in ticket 613

### DIFF
--- a/lgu2/templates/new_theme/advance_search/common/enacted-made.html
+++ b/lgu2/templates/new_theme/advance_search/common/enacted-made.html
@@ -7,7 +7,7 @@
     </fieldset>
 {% else %}
     <fieldset class="search-date current-design">
-        <legend><h2>Enacted or made dates</h2></legend>
+        <legend><h2>Year</h2></legend>
         <p>We hold legislation from 1267 to the present day, including all Primary legislation from 1988 and all Secondary legislation from 1987 - see a comprehensive list of <a href="#">what legislation we hold</a>.</p>
         <div role="group" aria-label="Specific year">
             <span>
@@ -19,7 +19,7 @@
             <span>
                 <label for="range">Search across a range of years</label><input id="range" type="radio" value="false" name="specifi_years" />
                 <span><label for="from-date">from:</label><input id="from-date" type="text" name="startYear" placeholder="1267" /></span>
-                <span><label for="to-date">to:</label><input id="to-date" type="text" name="endYear" placeholder="2025>" /></span>
+                <span><label for="to-date">to:</label><input id="to-date" type="text" name="endYear" placeholder="2025" /></span>
             </span>
         </div>
     </fieldset>

--- a/lgu2/templates/new_theme/advance_search/common/series-number.html
+++ b/lgu2/templates/new_theme/advance_search/common/series-number.html
@@ -4,9 +4,12 @@
     <span><label for="number">Number:</label><input id="number" type="text" placeholder="e.g. 15" /></span>
 </fieldset>
 {% else %}
-<fieldset class="search-number">
-    <legend><h2>Series and number</h2></legend>
+<fieldset class="search-number-series">
+    <legend><h2>Number</h2></legend>
     <p>Some legislation is assigned multiple numbers from different numbering systems. If you are unsure which number series to use, select 'Main series'.</p>
+    <span>
+        <label for="number">Number:</label><input id="number" name="number" type="text" placeholder="e.g. 15" />
+    </span>
     <span>
         <label for="series">Series:</label>
         <select id="series" name="series">
@@ -17,9 +20,6 @@
             <option value="c">Commencement</option>
             <option value="l">Legal</option>
         </select>
-    </span>
-    <span>
-        <label for="number">Number:</label><input id="number" name="number" type="text" placeholder="e.g. 15" />
     </span>
 </fieldset>
 {% endif %}

--- a/lgu2/templates/new_theme/common/footer.html
+++ b/lgu2/templates/new_theme/common/footer.html
@@ -3,8 +3,8 @@
 		<nav aria-labelledby="websiteInformation">
 			<h2 id="websiteInformation" class="sr-only">Website information</h2>
 			<ul>
-				<li><a href="{% url 'homepage' %}">Help</a></li>
-				<li><a href="{% url 'homepage' %}">About Us</a></li>
+				<li><a href="{% url 'help' %}">Help and guidance</a></li>
+				<li><a href="{% url 'about-us' %}">About Us</a></li>
 				<li><a href="#">Sitemap</a></li>
 				<li><a href="#">Accessibility</a></li>
 				<li><a href="#">Contact Us</a></li>

--- a/lgu2/templates/new_theme/common/header.html
+++ b/lgu2/templates/new_theme/common/header.html
@@ -123,7 +123,7 @@
 						</span>
 						<span>
 							<button type="submit">Search</button>
-							<a href="{% url 'advance-search' %}">Advanced Search</a>
+							<a href="{% url 'advance-search' %}">Advanced Searches</a>
 						</span>
 					</fieldset>
 				</form>

--- a/lgu2/templates/new_theme/document/document.html
+++ b/lgu2/templates/new_theme/document/document.html
@@ -16,7 +16,7 @@
 
     {% if links.toc %}
     <nav aria-labelledby="legislationNavigation" class="legislation-navigation">
-        <h2 id="legislationNavigation">Table of contents, previous and next provisions</h2>
+        <h2 id="legislationNavigation">Table of Contents, previous and next provisions</h2>
         {% if meta.prevInfo %}
         <a href="{{ meta.prev }}"><span><span>Previous: </span>{{ meta.prevInfo.label }}</span></a>
         {% else %}
@@ -102,7 +102,7 @@
 
                 {% if links.toc %}
                 <nav aria-label="Table of contents, previous and next provisions (after the legislation text)" class="legislation-navigation">
-                    <h2>Table of contents, previous and next provisions</h2>
+                    <h2>Table of Contents, previous and next provisions</h2>
                     {% if meta.prevInfo %}
                     <a href="{{ meta.prev }}"><span><span>Previous: </span>{{ meta.prevInfo.label }}</span></a>
                     {% else %}

--- a/lgu2/templates/new_theme/document/toc.html
+++ b/lgu2/templates/new_theme/document/toc.html
@@ -5,13 +5,13 @@
     <section>
         {% include "new_theme/common/breadcrumbs.html" %}
         <h1 id="main-content-h" tabindex="-1">
-            Table of contents 
+            Table of Contents 
             <br class="initialise" /><span>{{ meta.title }}</span>
         </h1>
     </section>
 
     <nav aria-labelledby="legislationNavigation" class="legislation-navigation">
-        <h2 id="legislationNavigation">Table of contents, previous and next provisions</h2>
+        <h2 id="legislationNavigation">Table of Contents, previous and next provisions</h2>
         <span></span>
         <span></span>
         <a href="{{ meta.next }}"><span><span>Next: </span>Introduction</span></a>
@@ -20,7 +20,7 @@
     <section class="pit-search">
         <h2>View this legislation at a specific date</h2>
         <details>
-            <summary>You are viewing the table of contents on <span>{{ current_date|date:"d M Y" }}</span><span> Enter a date</span></summary>
+            <summary>You are viewing the Table of Contents on <span>{{ current_date|date:"d M Y" }}</span><span> Enter a date</span></summary>
             <form role="search">
                 <h3>Change the date</h3>
                 <label for="pitDate">Date:</label>
@@ -39,8 +39,8 @@
             {% include "new_theme/document/status_panel.html" %}
             <section class="toc-detail">
                 {% if contents %}
-                <button hidden class="initialise expanded" id="toc"><span>Collapse table of contents</span></button>
-                <h2>Table of contents for this Act</h2>
+                <button hidden class="initialise expanded" id="toc"><span>Collapse Table of Contents</span></button>
+                <h2>Table of Contents for this Act</h2>
                 <ul>
                     <li><h3><a href="{{ links.whole }}">The whole Act</a></h3>
                         <ul>


### PR DESCRIPTION
fixed all the below issues 

"Advanced Search" → "Advanced Searches" [Browse 2]

"Help" → "Help and guidance" in the footer [Footer 23]

Capitalise T and C in "Table of Contents" everywhere [ToC 24]

Remove the ">" from the advanced search placeholder [Adv 25]

Rename "Enacted or made dates" → "Year" and "Series and number" → "Number", and use the revised Number/Series entry [Adv 24, Adv 26]