### PR TITLE
Add UK-amended filter for EU-originating legislation types

### DIFF
--- a/lgu2/api/browse_types.py
+++ b/lgu2/api/browse_types.py
@@ -43,6 +43,7 @@ class Counts(TypedDict):
 class ByType(TypedDict):
     type: str
     count: int
+    ukAmended: NotRequired[Optional[bool]]
 
 
 class ByYear(TypedDict):

--- a/lgu2/api/search.py
+++ b/lgu2/api/search.py
@@ -1,26 +1,39 @@
+from typing import Any, Dict
+
 from django.conf import settings
 import requests
 
-from .search_types import SearchParams
+from .search_types import ApiSearchRequest
 from .browse_types import DocumentList
 
 SERVER = settings.API_BASE_URL
 
 
-def basic_search(query_params: SearchParams) -> DocumentList:
-    """
-    Perform a basic search by forwarding query parameters to an external API.
-
-    Args:
-        query_params (SearchParams): Well-formed search parameters dictionary.
-
-    Returns:
-        DocumentList: Paginated list of legislation documents with metadata.
-    """
+def basic_search(query_params: ApiSearchRequest) -> DocumentList:
+    """Forward a search request to the external API."""
     api_url = f"{SERVER}/search"
-
-    response = requests.get(api_url, params=query_params)
+    response = requests.get(api_url, params=_to_wire(query_params))
     response.raise_for_status()
     data = response.json()
     DocumentList.convert_dates(data)
     return data
+
+
+def _to_wire(params: ApiSearchRequest) -> Dict[str, Any]:
+    """Coerce Python values to HTTP-query-string-friendly forms.
+
+    `requests` serialises booleans as Python repr ("True"/"False"); the
+    API expects lowercase "true"/"false".
+    """
+    out: Dict[str, Any] = {}
+    for key, value in params.items():
+        out[key] = _coerce(value)
+    return out
+
+
+def _coerce(value: Any) -> Any:
+    if isinstance(value, bool):
+        return 'true' if value else 'false'
+    if isinstance(value, list):
+        return [_coerce(v) for v in value]
+    return value

--- a/lgu2/api/search_types.py
+++ b/lgu2/api/search_types.py
@@ -1,14 +1,15 @@
 from typing import List, NotRequired, TypedDict, Union
 
 
-class SearchParams(TypedDict):
-    """Search parameters for the /search API endpoint.
+class ApiSearchRequest(TypedDict):
+    """Request shape for the /search endpoint.
 
-    Note: All parameters mirror the external API contract exactly.
-    The 'number' field accepts string-based legislation references
-    (e.g., "1", "w2", "ni15") not just numeric IDs.
+    Mirrors the API contract exactly; field names match the wire format
+    (e.g. `q` for the keyword field, not the view-side alias `text`).
     """
     year: NotRequired[int]
+    startYear: NotRequired[int]
+    endYear: NotRequired[int]
     type: NotRequired[Union[str, List[str]]]
     subject: NotRequired[str]
     pageSize: NotRequired[int]
@@ -16,5 +17,11 @@ class SearchParams(TypedDict):
     page: NotRequired[int]
     title: NotRequired[str]
     number: NotRequired[str]
+    q: NotRequired[str]
+    language: NotRequired[str]
+    pointInTime: NotRequired[str]
+    extent: NotRequired[List[str]]
+    exclusiveExtent: NotRequired[bool]
     stage: NotRequired[str]
     department: NotRequired[str]
+    ukAmended: NotRequired[bool]

--- a/lgu2/templates/new_theme/search_result/left_filter.html
+++ b/lgu2/templates/new_theme/search_result/left_filter.html
@@ -11,7 +11,7 @@
             <span class="close">Close<span> filters</span></span>
         </summary>
         <div>
-            {% if meta_data.counts.byType %}
+            {% if type_filter_groups %}
             <section class="filter-type">
                 <h3>By type</h3>
                 <ul>
@@ -22,19 +22,36 @@
                         </a>
                     </li>
 
-                    
-                    <!-- Show all types if no type is selected -->
-                    {% for all_types in meta_data.counts.byType %}
-                        {% with all_types.type|camel_to_words as converted_type %}
-                            <li>
-                                <a href="{{ all_types.link }}">
-                                    {{ converted_type.label_type }}
-                                    <span>({{ all_types.count }}<span> results</span>)</span>
+                    {% for group in type_filter_groups %}
+                        <li {% if group.parent.current %}aria-current="page"{% endif %}>
+                            {% if group.parent.current %}
+                                <span>
+                                    {{ group.label }}
+                                    <span>({{ group.parent.count }}<span> results</span>)</span>
+                                </span>
+                            {% else %}
+                                <a href="{{ group.parent.link }}">
+                                    {{ group.label }}
+                                    <span>({{ group.parent.count }}<span> results</span>)</span>
                                 </a>
+                            {% endif %}
+                        </li>
+                        {% for sub in group.sub_entries %}
+                            <li {% if sub.current %}aria-current="page"{% endif %}>
+                                {% if sub.current %}
+                                    <span>
+                                        {{ sub.label }}
+                                        <span>({{ sub.count }}<span> results</span>)</span>
+                                    </span>
+                                {% else %}
+                                    <a href="{{ sub.link }}">
+                                        {{ sub.label }}
+                                        <span>({{ sub.count }}<span> results</span>)</span>
+                                    </a>
+                                {% endif %}
                             </li>
-                        {% endwith %}
+                        {% endfor %}
                     {% endfor %}
-                
                 </ul>
             </section>
             {% endif %}

--- a/lgu2/templates/new_theme/search_result/search_result.html
+++ b/lgu2/templates/new_theme/search_result/search_result.html
@@ -9,8 +9,8 @@
 		<hgroup>
 			<h1 id="main-content-h" tabindex="-1">We found {{meta_data.counts.total}} documents</h1>
 			<p>
-				{% for key, value in meta_data.query.items %}
-					<a href='{{modified_query_links|dict_key:key}}'><span>{{key}}: {{value}}</span></a>
+				{% for chip in active_filters %}
+					<a href='{{ chip.remove_link }}'><span>{{ chip.label }}{% if chip.value %}: {{ chip.value }}{% endif %}</span></a>
 				{% endfor %}
 			</p>
 		</hgroup>
@@ -25,7 +25,7 @@
 			<div class="sort-by">
 				<form method="get" action="{% url 'search' %}">
 					<!-- Preserve existing query parameters -->
-					{% for key, value in query_param.items %}
+					{% for key, value in query_param_ui.items %}
 						{% if key != 'sort' %}
 							{% for v in value|as_list %}
 								<input type="hidden" name="{{key}}" value="{{v}}">
@@ -117,7 +117,7 @@
 			<form role="search" method="get" action="{% url 'search' %}">
 			<div class="results-per-page">
 				<label for="resultsPerPage">Results per page:</label>
-				{% for key, value in query_param.items %}
+				{% for key, value in query_param_ui.items %}
 					{% if key != 'pageSize' %}
 						{% for v in value|as_list %}
 							<input type="hidden" name="{{key}}" value="{{v}}">

--- a/lgu2/tests/test_search_urls.py
+++ b/lgu2/tests/test_search_urls.py
@@ -216,14 +216,15 @@ class TestModifiedQueryLinksRendering(TestCase):
 
     @patch("lgu2.views.search.basic_search")
     def test_text_filter_chip_has_working_removal_link(self, mock_basic_search):
-        # The API reports the keyword filter as q; the template iterates over
-        # meta.query, so the "text" removal link must be reachable under q too.
+        # The API reports the keyword filter as q, but chips are built from
+        # internal query_params (which use the SearchParams key 'text').
         mock_basic_search.return_value = _empty_search_response(q="fire")
 
         response = self.client.get("/ukpga", {"text": "fire"})
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["meta_data"]["query"], {"text": "fire"})
+        chip_keys = [c["key"] for c in response.context["active_filters"]]
+        self.assertIn("text", chip_keys)
         self.assertIn("text", response.context["modified_query_links"])
 
 

--- a/lgu2/tests/test_uk_amended.py
+++ b/lgu2/tests/test_uk_amended.py
@@ -1,0 +1,452 @@
+from unittest.mock import patch
+
+from django.test import RequestFactory, TestCase
+
+from lgu2.util.global_redirect import build_browse_url_if_possible
+from lgu2.util.search_params import from_api_response, to_api_request
+from lgu2.util.url_params import to_ui_params
+from lgu2.views.search import (
+    enforce_uk_amended_invariant,
+    extract_query_params,
+    make_smart_link,
+    replace_param_and_make_smart_link,
+)
+
+
+def _eu_search_response(query=None):
+    """Build a minimal API response with three EU byType rows (parent + true + false)."""
+    return {
+        'meta': {
+            'page': 1,
+            'totalPages': 1,
+            'query': query or {},
+            'subjects': [],
+            'counts': {
+                'total': 0,
+                'byType': [
+                    {'type': 'EuropeanUnionRegulation', 'count': 1234},
+                    {'type': 'EuropeanUnionRegulation', 'count': 47, 'ukAmended': True},
+                    {'type': 'EuropeanUnionRegulation', 'count': 1187, 'ukAmended': False},
+                ],
+                'byYear': [],
+                'bySubjectInitial': [],
+                'byStage': [],
+                'byDepartment': [],
+            },
+        },
+        'documents': [],
+    }
+
+
+class TestBuildBrowseUrlUkAmended(TestCase):
+    """ukAmended is preserved on browse URLs as the lowercase ukamended key."""
+
+    def test_eu_type_with_uk_amended_true(self):
+        result = build_browse_url_if_possible({'type': 'eur', 'ukAmended': True})
+        self.assertEqual(result, '/eur?ukamended=true')
+
+    def test_eu_type_with_uk_amended_false(self):
+        result = build_browse_url_if_possible({'type': 'eur', 'ukAmended': False})
+        self.assertEqual(result, '/eur?ukamended=false')
+
+    def test_eu_type_with_year_and_uk_amended(self):
+        result = build_browse_url_if_possible({'type': 'eur', 'year': 2024, 'ukAmended': False})
+        self.assertEqual(result, '/eur/2024?ukamended=false')
+
+    def test_uk_amended_uses_lowercase_value_not_python_repr(self):
+        result = build_browse_url_if_possible({'type': 'eur', 'ukAmended': True})
+        self.assertNotIn('True', result)
+        self.assertNotIn('ukAmended', result)
+
+
+class TestToApiRequest(TestCase):
+    def test_renames_text_to_q(self):
+        out = to_api_request({'text': 'fire'})
+        self.assertEqual(out, {'q': 'fire'})
+        self.assertNotIn('text', out)
+
+    def test_uk_amended_keeps_camelcase(self):
+        out = to_api_request({'type': 'eur', 'ukAmended': True})
+        self.assertEqual(out, {'type': 'eur', 'ukAmended': True})
+
+    def test_does_not_mutate_input(self):
+        params = {'text': 'fire', 'type': 'ukpga'}
+        to_api_request(params)
+        self.assertEqual(params, {'text': 'fire', 'type': 'ukpga'})
+
+
+class TestFromApiResponse(TestCase):
+    def test_renames_meta_query_q_to_text(self):
+        api = {'meta': {'query': {'q': 'fire', 'sort': 'title'}}, 'documents': []}
+        out = from_api_response(api)
+        self.assertEqual(out['meta']['query'], {'text': 'fire', 'sort': 'title'})
+
+    def test_does_not_mutate_input(self):
+        api = {'meta': {'query': {'q': 'fire'}}, 'documents': []}
+        from_api_response(api)
+        self.assertEqual(api['meta']['query'], {'q': 'fire'})
+
+    def test_passes_through_when_no_q(self):
+        api = {'meta': {'query': {'sort': 'title'}}, 'documents': []}
+        out = from_api_response(api)
+        self.assertEqual(out['meta']['query'], {'sort': 'title'})
+
+    def test_handles_missing_query(self):
+        api = {'meta': {}, 'documents': []}
+        out = from_api_response(api)
+        self.assertEqual(out['meta'], {})
+
+
+class TestToUiParams(TestCase):
+    def test_renames_uk_amended_to_lowercase(self):
+        out = to_ui_params({'type': 'eur', 'ukAmended': False})
+        self.assertEqual(out, {'type': 'eur', 'ukamended': 'false'})
+
+    def test_other_camelcase_keys_not_renamed(self):
+        out = to_ui_params({'startYear': 1900, 'pageSize': 20})
+        self.assertEqual(out, {'startYear': 1900, 'pageSize': 20})
+
+    def test_lowercases_booleans(self):
+        out = to_ui_params({'ukAmended': True})
+        self.assertEqual(out, {'ukamended': 'true'})
+
+
+class TestExtractQueryParamsUkAmended(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_lowercase_true_is_parsed_as_internal_camelcase_key(self):
+        request = self.factory.get('/search/?ukamended=true')
+        params = extract_query_params(request)
+        self.assertIs(params.get('ukAmended'), True)
+        self.assertNotIn('ukamended', params)
+
+    def test_lowercase_false_is_parsed(self):
+        request = self.factory.get('/search/?ukamended=false')
+        params = extract_query_params(request)
+        self.assertIs(params.get('ukAmended'), False)
+
+    def test_mixed_case_value_is_accepted(self):
+        request = self.factory.get('/search/?ukamended=TRUE')
+        params = extract_query_params(request)
+        self.assertIs(params.get('ukAmended'), True)
+
+    def test_other_values_are_dropped(self):
+        for bad in ('1', '0', 'yes', 'no', 'maybe', ''):
+            with self.subTest(value=bad):
+                request = self.factory.get('/search/?ukamended=' + bad)
+                params = extract_query_params(request)
+                self.assertNotIn('ukAmended', params)
+
+
+class TestEnforceUkAmendedInvariant(TestCase):
+    def test_eu_atomic_type_preserves_uk_amended(self):
+        params = {'type': 'eur', 'ukAmended': True}
+        enforce_uk_amended_invariant(params)
+        self.assertIs(params.get('ukAmended'), True)
+
+    def test_non_eu_type_strips_uk_amended(self):
+        params = {'type': 'ukpga', 'ukAmended': True}
+        enforce_uk_amended_invariant(params)
+        self.assertNotIn('ukAmended', params)
+
+    def test_no_type_strips_uk_amended(self):
+        params = {'ukAmended': True}
+        enforce_uk_amended_invariant(params)
+        self.assertNotIn('ukAmended', params)
+
+    def test_compound_set_with_any_eu_member_preserves(self):
+        params = {'type': ['eur', 'ukpga'], 'ukAmended': True}
+        enforce_uk_amended_invariant(params)
+        self.assertIs(params.get('ukAmended'), True)
+
+    def test_compound_set_all_non_eu_strips(self):
+        params = {'type': ['ukpga', 'uksi'], 'ukAmended': True}
+        enforce_uk_amended_invariant(params)
+        self.assertNotIn('ukAmended', params)
+
+    def test_eu_origin_aggregate_token_preserves(self):
+        params = {'type': ['eu-origin'], 'ukAmended': True}
+        enforce_uk_amended_invariant(params)
+        self.assertIs(params.get('ukAmended'), True)
+
+    def test_eu_aggregate_token_preserves(self):
+        params = {'type': ['eu'], 'ukAmended': True}
+        enforce_uk_amended_invariant(params)
+        self.assertIs(params.get('ukAmended'), True)
+
+    def test_other_eu_atomic_types_preserve(self):
+        for t in ('eudn', 'eudr', 'eut'):
+            with self.subTest(type=t):
+                params = {'type': t, 'ukAmended': False}
+                enforce_uk_amended_invariant(params)
+                self.assertIs(params.get('ukAmended'), False)
+
+
+class TestReplaceParamAndMakeSmartLink(TestCase):
+    """Switching or clearing type re-applies the EU-type invariant."""
+
+    def test_switch_eu_to_non_eu_strips_uk_amended(self):
+        url = replace_param_and_make_smart_link(
+            {'type': 'eur', 'ukAmended': True}, 'type', 'ukpga'
+        )
+        self.assertNotIn('ukAmended', url)
+        self.assertNotIn('ukamended', url)
+
+    def test_clear_type_strips_uk_amended(self):
+        url = replace_param_and_make_smart_link(
+            {'type': 'eur', 'ukAmended': True}, 'type', None
+        )
+        self.assertNotIn('ukAmended', url)
+        self.assertNotIn('ukamended', url)
+
+    def test_clear_uk_amended_preserves_eu_type(self):
+        url = replace_param_and_make_smart_link(
+            {'type': 'eur', 'ukAmended': True}, 'ukAmended', None
+        )
+        self.assertEqual(url, '/eur')
+
+    def test_switch_eu_to_other_eu_keeps_uk_amended(self):
+        url = replace_param_and_make_smart_link(
+            {'type': 'eur', 'ukAmended': True}, 'type', 'eudr'
+        )
+        self.assertEqual(url, '/eudr?ukamended=true')
+
+
+class TestBrowseViewPathThenInvariant(TestCase):
+    """Path-derived type is honoured by the invariant; non-EU paths strip ukAmended."""
+
+    @patch('lgu2.views.search.basic_search')
+    def test_eu_path_with_uk_amended_query_preserves_filter(self, mock_basic_search):
+        mock_basic_search.return_value = _eu_search_response(query={'type': 'eur', 'ukAmended': True})
+        response = self.client.get('/eur', {'ukamended': 'true'})
+        self.assertEqual(response.status_code, 200)
+        api_params = mock_basic_search.call_args.args[0]
+        self.assertIs(api_params.get('ukAmended'), True)
+
+    @patch('lgu2.views.search.basic_search')
+    def test_non_eu_path_with_uk_amended_query_strips_filter(self, mock_basic_search):
+        mock_basic_search.return_value = {
+            'meta': {
+                'page': 1, 'totalPages': 1, 'query': {}, 'subjects': [],
+                'counts': {'total': 0, 'byType': [], 'byYear': [],
+                           'bySubjectInitial': [], 'byStage': [], 'byDepartment': []},
+            },
+            'documents': [],
+        }
+        response = self.client.get('/ukpga', {'ukamended': 'true'})
+        self.assertEqual(response.status_code, 200)
+        api_params = mock_basic_search.call_args.args[0]
+        self.assertNotIn('ukAmended', api_params)
+
+
+class TestSearchRedirectAppliesInvariantEarly(TestCase):
+    """A /search?type=ukpga&ukamended=true URL should canonicalise to /ukpga, not /ukpga?ukamended=true."""
+
+    @patch('lgu2.views.search.basic_search')
+    def test_redirect_drops_orphan_uk_amended(self, mock_basic_search):
+        response = self.client.get('/search/', {'type': 'ukpga', 'ukamended': 'true'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/ukpga')
+
+
+class TestApiClientForwardsCamelCase(TestCase):
+    @patch('lgu2.api.search.requests.get')
+    def test_api_client_keeps_camelcase_ukAmended(self, mock_get):
+        mock_get.return_value.json.return_value = {
+            'meta': {'updated': '2024-01-01T00:00:00Z'},
+            'documents': [],
+        }
+        mock_get.return_value.raise_for_status.return_value = None
+        from lgu2.api.search import basic_search
+        basic_search({'type': 'eur', 'ukAmended': True})
+        params_arg = mock_get.call_args.kwargs['params']
+        # API forwarding keeps camelCase ukAmended; bool is wire-coerced
+        # to lowercase string inside basic_search.
+        self.assertIn('ukAmended', params_arg)
+        self.assertNotIn('ukamended', params_arg)
+        self.assertEqual(params_arg['ukAmended'], 'true')
+
+
+class TestTypeFilterGroups(TestCase):
+    @patch('lgu2.views.search.basic_search')
+    def test_eu_type_groups_into_parent_with_two_sub_entries(self, mock_basic_search):
+        mock_basic_search.return_value = _eu_search_response(query={'type': 'eur'})
+        response = self.client.get('/eur')
+        self.assertEqual(response.status_code, 200)
+        groups = response.context['type_filter_groups']
+        self.assertEqual(len(groups), 1)
+        group = groups[0]
+        self.assertEqual(group['base_type'], 'eur')
+        self.assertEqual(group['parent']['count'], 1234)
+        self.assertEqual(len(group['sub_entries']), 2)
+        # Sorted Amended → Not amended
+        self.assertIs(group['sub_entries'][0]['ukAmended'], True)
+        self.assertIs(group['sub_entries'][1]['ukAmended'], False)
+        self.assertEqual(group['sub_entries'][0]['count'], 47)
+        self.assertEqual(group['sub_entries'][1]['count'], 1187)
+
+    @patch('lgu2.views.search.basic_search')
+    def test_unqualified_only_groups_have_no_sub_entries(self, mock_basic_search):
+        mock_basic_search.return_value = {
+            'meta': {
+                'page': 1, 'totalPages': 1, 'query': {'type': 'ukpga'}, 'subjects': [],
+                'counts': {
+                    'total': 1,
+                    'byType': [{'type': 'UnitedKingdomPublicGeneralAct', 'count': 1}],
+                    'byYear': [], 'bySubjectInitial': [], 'byStage': [], 'byDepartment': [],
+                },
+            },
+            'documents': [],
+        }
+        response = self.client.get('/ukpga')
+        groups = response.context['type_filter_groups']
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]['sub_entries'], [])
+
+    @patch('lgu2.views.search.basic_search')
+    def test_groups_without_parent_row_are_dropped(self, mock_basic_search):
+        # If the API misbehaves and returns only qualified rows for a type,
+        # the group is omitted entirely rather than rendered with an empty
+        # parent link — Django trusts API counts and won't synthesise one.
+        mock_basic_search.return_value = {
+            'meta': {
+                'page': 1, 'totalPages': 1, 'query': {}, 'subjects': [],
+                'counts': {
+                    'total': 0,
+                    'byType': [
+                        {'type': 'EuropeanUnionRegulation', 'count': 47, 'ukAmended': True},
+                        {'type': 'EuropeanUnionRegulation', 'count': 1187, 'ukAmended': False},
+                    ],
+                    'byYear': [], 'bySubjectInitial': [], 'byStage': [], 'byDepartment': [],
+                },
+            },
+            'documents': [],
+        }
+        response = self.client.get('/eur')
+        groups = response.context['type_filter_groups']
+        self.assertEqual(groups, [])
+
+    @patch('lgu2.views.search.basic_search')
+    def test_no_synthesised_all_sub_entry(self, mock_basic_search):
+        mock_basic_search.return_value = _eu_search_response()
+        response = self.client.get('/eur')
+        groups = response.context['type_filter_groups']
+        self.assertEqual(len(groups[0]['sub_entries']), 2)
+
+    @patch('lgu2.views.search.basic_search')
+    def test_group_collapses_to_matching_sub_entry_when_filtered(self, mock_basic_search):
+        # When ukAmended is active, the API can't return reliable parent or
+        # opposite-sub-entry counts. The group collapses to a single row
+        # showing only the matching sub-entry, promoted into the parent slot.
+        mock_basic_search.return_value = _eu_search_response(query={'type': 'eur', 'ukAmended': True})
+        response = self.client.get('/eur', {'ukamended': 'true'})
+        group = response.context['type_filter_groups'][0]
+        self.assertEqual(group['sub_entries'], [])
+        self.assertEqual(group['parent']['count'], 47)
+        self.assertTrue(group['parent']['current'])
+        self.assertIn('that are amended by the UK', group['label'])
+
+
+class TestActiveFiltersChipModel(TestCase):
+    @patch('lgu2.views.search.basic_search')
+    def test_uk_amended_chip_built_from_query_params_not_meta_echo(self, mock_basic_search):
+        # API echo deliberately omits ukAmended; the chip should still appear
+        # because it comes from query_params, not meta.query.
+        response_data = _eu_search_response(query={'type': 'eur'})
+        mock_basic_search.return_value = response_data
+        response = self.client.get('/eur', {'ukamended': 'true'})
+        chips = response.context['active_filters']
+        chip_keys = [c['key'] for c in chips]
+        self.assertIn('ukAmended', chip_keys)
+        chip = next(c for c in chips if c['key'] == 'ukAmended')
+        self.assertEqual(chip['label'], 'Amended by UK legislation')
+        self.assertIsNone(chip['value'])
+
+    @patch('lgu2.views.search.basic_search')
+    def test_uk_amended_chip_remove_link_clears_only_that_param(self, mock_basic_search):
+        mock_basic_search.return_value = _eu_search_response(query={'type': 'eur'})
+        response = self.client.get('/eur', {'ukamended': 'false'})
+        chips = response.context['active_filters']
+        chip = next(c for c in chips if c['key'] == 'ukAmended')
+        self.assertEqual(chip['remove_link'], '/eur')
+
+    @patch('lgu2.views.search.basic_search')
+    def test_not_amended_chip_uses_correct_label(self, mock_basic_search):
+        mock_basic_search.return_value = _eu_search_response(query={'type': 'eur'})
+        response = self.client.get('/eur', {'ukamended': 'false'})
+        chips = response.context['active_filters']
+        chip = next(c for c in chips if c['key'] == 'ukAmended')
+        self.assertEqual(chip['label'], 'Not amended by UK legislation')
+
+
+class TestYearRangeChipRemoveLink(TestCase):
+    """A year range arrives as separate startYear+endYear chips. Removing
+    either chip must clear the whole range, not leave a half-range behind."""
+
+    @patch('lgu2.views.search.basic_search')
+    def test_year_range_chips_remove_link_clears_whole_range(self, mock_basic_search):
+        mock_basic_search.return_value = {
+            'meta': {
+                'page': 1, 'totalPages': 1,
+                'query': {'type': 'ukpga', 'startYear': 1900, 'endYear': 2000},
+                'subjects': [],
+                'counts': {
+                    'total': 0, 'byType': [], 'byYear': [],
+                    'bySubjectInitial': [], 'byStage': [], 'byDepartment': [],
+                },
+            },
+            'documents': [],
+        }
+        response = self.client.get('/ukpga/1900-2000')
+        chips = {c['key']: c for c in response.context['active_filters']}
+        self.assertEqual(chips['startYear']['remove_link'], '/ukpga')
+        self.assertEqual(chips['endYear']['remove_link'], '/ukpga')
+
+
+class TestExtentRemoveLinkIsClean(TestCase):
+    """Removing `extent` should also drop the now-dangling exclusiveExtent
+    flag — normalize_params_for_browse() handles this implicitly. Lock it in."""
+
+    def test_remove_extent_drops_exclusive_flag(self):
+        link = replace_param_and_make_smart_link(
+            {'type': 'ukpga', 'extent': ['E'], 'exclusiveExtent': True},
+            'extent',
+            None,
+        )
+        self.assertEqual(link, '/ukpga')
+
+
+class TestAllLegislationTypesLinkClearsUkAmended(TestCase):
+    @patch('lgu2.views.search.basic_search')
+    def test_modified_query_links_type_clears_uk_amended(self, mock_basic_search):
+        mock_basic_search.return_value = _eu_search_response(query={'type': 'eur', 'ukAmended': True})
+        response = self.client.get('/eur', {'ukamended': 'true'})
+        links = response.context['modified_query_links']
+        # Clearing type strips ukAmended via the invariant.
+        self.assertEqual(links['type'], '/search/')
+
+
+class TestHiddenFormInputsUseUiKey(TestCase):
+    """The sort and pageSize forms re-submit to /search/, which only reads
+    the lowercase `ukamended` key. Hidden inputs must therefore use the UI
+    spelling, not the internal camelCase `ukAmended`."""
+
+    @patch('lgu2.views.search.basic_search')
+    def test_hidden_inputs_emit_lowercase_ukamended(self, mock_basic_search):
+        mock_basic_search.return_value = _eu_search_response(query={'type': 'eur', 'ukAmended': True})
+        response = self.client.get('/eur', {'ukamended': 'true'})
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn('name="ukamended"', content)
+        self.assertNotIn('name="ukAmended"', content)
+        # Boolean values must be lowercased too — Python repr "True" is wrong.
+        self.assertIn('value="true"', content)
+
+
+class TestMakeSmartLinkUiSerialization(TestCase):
+    def test_smart_link_emits_lowercase_ukamended_when_falling_back_to_search(self):
+        url = make_smart_link({'type': 'eur', 'ukAmended': True, 'sort': 'title'})
+        self.assertIn('ukamended=true', url)
+        self.assertNotIn('ukAmended', url)
+        self.assertNotIn('True', url)

--- a/lgu2/util/global_redirect.py
+++ b/lgu2/util/global_redirect.py
@@ -2,7 +2,8 @@ from typing import Any, Dict, Optional
 from urllib.parse import urlencode
 from django.urls import reverse, NoReverseMatch
 from ..util.types import SEARCH_TYPES
-from ..api.search_types import SearchParams
+from ..util.url_params import to_ui_params
+from ..util.search_params import SearchParams
 
 EXTENT_MAP = {
     "E": "england",
@@ -80,10 +81,14 @@ def build_browse_url_if_possible(params: SearchParams) -> Optional[str]:
     Handles type(s), year, subject, extent_segment, and exclusiveExtent.
     """
     params = normalize_params_for_browse(params)
+    # Apply UI translations (ukAmended → ukamended, bool → "true"/"false")
+    # before the allowlist check so the allowlist key matches the URL form.
+    params = to_ui_params(params)
 
     allowed_keys = {
         'type', 'year', 'subject', 'extent_segment',
-        'page', 'pageSize', 'title', 'language', 'text', 'number'
+        'page', 'pageSize', 'title', 'language', 'text', 'number',
+        'ukamended',
     }
     if not set(params).issubset(allowed_keys):
         return None

--- a/lgu2/util/search_params.py
+++ b/lgu2/util/search_params.py
@@ -1,0 +1,57 @@
+"""View-side search parameter shape and the translator that prepares it
+for the API client.
+
+`SearchParams` is the shape views build to describe a search. It uses
+view-friendly names (e.g. `text` for the keyword field), which the
+translator below maps onto the API's contract before forwarding.
+"""
+from typing import List, NotRequired, TypedDict, Union
+
+from ..api.browse_types import DocumentList
+from ..api.search_types import ApiSearchRequest
+
+
+class SearchParams(TypedDict):
+    year: NotRequired[int]
+    startYear: NotRequired[int]
+    endYear: NotRequired[int]
+    type: NotRequired[Union[str, List[str]]]
+    subject: NotRequired[str]
+    pageSize: NotRequired[int]
+    sort: NotRequired[str]
+    page: NotRequired[int]
+    title: NotRequired[str]
+    number: NotRequired[str]
+    text: NotRequired[str]
+    language: NotRequired[str]
+    pointInTime: NotRequired[str]
+    extent: NotRequired[List[str]]
+    exclusiveExtent: NotRequired[bool]
+    stage: NotRequired[str]
+    department: NotRequired[str]
+    ukAmended: NotRequired[bool]
+
+
+# View-side key → API-side key renames. Single source of truth for the
+# name divergences between SearchParams and ApiSearchRequest.
+_VIEW_TO_API = {"text": "q"}
+_API_TO_VIEW = {v: k for k, v in _VIEW_TO_API.items()}
+
+
+def to_api_request(params: SearchParams) -> ApiSearchRequest:
+    """Translate a view-side SearchParams into the API's request shape."""
+    return {_VIEW_TO_API.get(k, k): v for k, v in params.items()}  # type: ignore[return-value]
+
+
+def from_api_response(response: DocumentList) -> DocumentList:
+    """Translate an API search response into the view-side shape.
+
+    Renames `meta.query` keys back to view-side names (e.g. `q` → `text`)
+    so view-side consumers see the same keys they used to build the
+    request. Returns a new object; the input is not mutated.
+    """
+    out: DocumentList = {**response, "meta": {**response["meta"]}}
+    query = response["meta"].get("query")
+    if query is not None:
+        out["meta"]["query"] = {_API_TO_VIEW.get(k, k): v for k, v in query.items()}
+    return out

--- a/lgu2/util/types.py
+++ b/lgu2/util/types.py
@@ -53,6 +53,13 @@ SEARCH_TYPES = [item[0] for item in types] + [
     'eu-origin', 'eu', 'ukia',
 ]
 
+EU_ORIGINATING_TYPES = frozenset(item[0] for item in types if item[2] == 'euretained')
+EU_TYPE_TOKENS = EU_ORIGINATING_TYPES | {'eu-origin', 'eu'}
+
+
+def is_eu_originating_type(type_: str) -> bool:
+    return type_ in EU_TYPE_TOKENS
+
 
 def to_short_type(type):
     if type in short_to_long:

--- a/lgu2/util/url_params.py
+++ b/lgu2/util/url_params.py
@@ -1,0 +1,32 @@
+from typing import Any, Dict
+
+from .search_params import SearchParams
+
+
+# Internal-key → UI-URL-key renames. The UI URL spells `ukamended` all
+# lowercase, unlike the API. Other camelCase params (startYear, pageSize)
+# keep their casing in UI URLs.
+_UI_KEY_RENAMES = {
+    'ukAmended': 'ukamended',
+}
+
+
+def to_ui_params(params: SearchParams) -> Dict[str, Any]:
+    """Translate SearchParams to a dict suitable for emitting in UI URLs.
+
+    Booleans are lowercased to "true"/"false"; ukAmended is renamed to
+    ukamended.
+    """
+    out: Dict[str, Any] = {}
+    for key, value in params.items():
+        out_key = _UI_KEY_RENAMES.get(key, key)
+        out[out_key] = _coerce(value)
+    return out
+
+
+def _coerce(value: Any) -> Any:
+    if isinstance(value, bool):
+        return 'true' if value else 'false'
+    if isinstance(value, list):
+        return [_coerce(v) for v in value]
+    return value

--- a/lgu2/views/search.py
+++ b/lgu2/views/search.py
@@ -7,13 +7,14 @@ from django.shortcuts import render, redirect
 from django.urls import reverse
 
 from ..api.search import basic_search
-from ..api.search_types import SearchParams
 from ..util.cutoff import get_cutoff
-from ..util.types import get_category, to_short_type
+from ..util.search_params import SearchParams, from_api_response, to_api_request
+from ..util.types import get_category, is_eu_originating_type, to_short_type
 from ..util.version import get_first_version
 from ..util.labels import get_type_label
 from ..util.links import make_contents_link_for_list_entry, make_document_link
 from ..util.global_redirect import build_browse_url_if_possible, normalize_params_for_browse, parse_extent_segment
+from ..util.url_params import to_ui_params
 
 
 class SearchResultContext(TypedDict):
@@ -25,8 +26,6 @@ class SearchResultContext(TypedDict):
     total_pages: int
     current_subject: Optional[str]
     subject_heading: Optional[str]
-    total_count_by_type: int
-    total_count_by_year: int
     modified_query_links: Dict[str, str]
     query_params: str
     query_param: SearchParams
@@ -43,6 +42,29 @@ class SearchResultContext(TypedDict):
     default_pagesize: int
     type_label_plural: str
     type_made_verb: str
+    type_filter_groups: List[Dict[str, Any]]
+    active_filters: List[Dict[str, Any]]
+    query_param_ui: Dict[str, Any]
+
+
+def enforce_uk_amended_invariant(params: SearchParams) -> SearchParams:
+    """Drop ukAmended unless params['type'] contains an EU-originating type.
+
+    Mutates and returns the dict. Compound type sets are EU-positive when
+    any member is EU-originating; aggregate tokens 'eu-origin' / 'eu' count.
+    """
+    if 'ukAmended' not in params:
+        return params
+    type_value = params.get('type')
+    if isinstance(type_value, list):
+        type_values = type_value
+    elif isinstance(type_value, str):
+        type_values = [type_value]
+    else:
+        type_values = []
+    if not any(is_eu_originating_type(t) for t in type_values):
+        params.pop('ukAmended', None)
+    return params
 
 
 def parse_year_param(year: str) -> SearchParams:
@@ -134,23 +156,187 @@ def extract_query_params(request) -> SearchParams:
     if 'department' in request.GET and request.GET['department']:
         params['department'] = request.GET['department']
 
+    # ukamended (UI URL spelling, all lowercase) → ukAmended (internal/API).
+    # Only literal "true"/"false" (case-insensitive) are accepted; other
+    # values are dropped. EU-type invariant is applied later, after path
+    # params are merged.
+    uk_amended = request.GET.get('ukamended')
+    if uk_amended is not None:
+        normalized = uk_amended.strip().lower()
+        if normalized == 'true':
+            params['ukAmended'] = True
+        elif normalized == 'false':
+            params['ukAmended'] = False
+
     return params
 
 def make_smart_link(params: SearchParams):
+    """Build a UI URL from already-normalised SearchParams.
+
+    Callers must ensure params already satisfy the EU-type invariant — for
+    any link that changes or clears `type`, route through
+    `replace_param_and_make_smart_link` which re-applies the invariant.
+    """
     browse_url = build_browse_url_if_possible(params)
-    return browse_url or f"{reverse('search')}?{urlencode(params, doseq=True)}"
+    if browse_url:
+        return browse_url
+    ui_params = to_ui_params(params)
+    qs = urlencode(ui_params, doseq=True)
+    base = reverse('search')
+    return f"{base}?{qs}" if qs else base
 
 
-def replace_param_and_make_smart_link(params: SearchParams, key: str, value):
+def _change_params_and_make_smart_link(params: SearchParams, changes: Dict[str, Any]) -> str:
+    """Copy `params`, apply `changes` (None→pop, else set), drop pagination,
+    and build a smart link. The EU-type invariant is re-applied only when
+    `type` is among the changed keys — other mutations can't affect it.
+    """
     new_params = params.copy()
-    if value is None:
-        new_params.pop(key, None)
-    else:
-        new_params[key] = value
-
+    for key, value in changes.items():
+        if value is None:
+            new_params.pop(key, None)
+        else:
+            new_params[key] = value
     new_params.pop("page", None)
     new_params.pop("pageSize", None)
+    if "type" in changes:
+        enforce_uk_amended_invariant(new_params)
     return make_smart_link(new_params)
+
+
+def replace_param_and_make_smart_link(params: SearchParams, key: str, value) -> str:
+    return _change_params_and_make_smart_link(params, {key: value})
+
+
+_UK_AMENDED_CHIP_LABELS = {
+    True: "Amended by UK legislation",
+    False: "Not amended by UK legislation",
+}
+
+_UK_AMENDED_SUFFIXES = {
+    True: "that are amended by the UK",
+    False: "that are not amended by the UK",
+}
+
+# Internal SearchParams keys that aren't user-facing filter chips.
+_NON_CHIP_KEYS = frozenset({"page", "pageSize", "sort", "exclusiveExtent"})
+
+
+def _make_type_facet_link(query_params: SearchParams, short_type: str, uk_amended) -> str:
+    return _change_params_and_make_smart_link(
+        query_params, {"type": short_type, "ukAmended": uk_amended}
+    )
+
+
+def _build_type_filter_groups(by_type_rows, query_params: SearchParams, single_type):
+    """Group flat byType API rows by base short_type, producing a view-model
+    list with parent + sub_entries (each carrying a `current` flag).
+
+    Sub-entries are sorted Amended → Not amended.
+    """
+    active_uk_amended = query_params.get("ukAmended")
+    has_uk_amended_filter = "ukAmended" in query_params
+
+    groups_by_type: Dict[str, Dict[str, Any]] = {}
+    ordered: List[Dict[str, Any]] = []
+
+    for row in by_type_rows:
+        short_type = to_short_type(row["type"])
+        uk_amended = row.get("ukAmended")
+        link = _make_type_facet_link(query_params, short_type, uk_amended)
+        is_type_active = (single_type == short_type)
+
+        group = groups_by_type.get(short_type)
+        if group is None:
+            group = {
+                "base_type": short_type,
+                "label": get_type_label(short_type),
+                "parent": None,
+                "sub_entries": [],
+            }
+            groups_by_type[short_type] = group
+            ordered.append(group)
+
+        if uk_amended is None:
+            group["parent"] = {
+                "count": row["count"],
+                "link": link,
+                "current": is_type_active and not has_uk_amended_filter,
+            }
+        else:
+            group["sub_entries"].append({
+                "ukAmended": uk_amended,
+                "label": f"{group['label']} {_UK_AMENDED_SUFFIXES[uk_amended]}",
+                "count": row["count"],
+                "link": link,
+                "current": is_type_active and active_uk_amended is uk_amended,
+            })
+
+    for group in ordered:
+        group["sub_entries"].sort(key=lambda e: not e["ukAmended"])
+
+    # When a ukAmended filter is active, the API can't return reliable counts
+    # for the parent total or the opposite sub-entry — collapse the group to
+    # the single matching sub-entry, promoted into the parent slot.
+    if has_uk_amended_filter:
+        collapsed: List[Dict[str, Any]] = []
+        for group in ordered:
+            match = next(
+                (e for e in group["sub_entries"] if e["ukAmended"] is active_uk_amended),
+                None,
+            )
+            if match is None:
+                continue
+            group["label"] = match["label"]
+            group["parent"] = {
+                "count": match["count"],
+                "link": match["link"],
+                "current": match["current"],
+            }
+            group["sub_entries"] = []
+            collapsed.append(group)
+        return collapsed
+
+    # Drop groups whose parent row was missing from the API: Django doesn't
+    # synthesise counts (per the ADR), so omit rather than render an empty link.
+    return [g for g in ordered if g["parent"] is not None]
+
+
+_YEAR_RANGE_KEYS = frozenset({"year", "startYear", "endYear"})
+
+
+def _build_active_filters(
+    query_params: SearchParams,
+    year_clear_link: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Active-filter chips, built from normalized query_params.
+
+    Each chip carries a friendly label, an optional value, and a removal
+    link. For year/startYear/endYear, `year_clear_link` (if provided) is
+    used so removing one half of a range escapes the whole filter; without
+    it, clearing only one key would leave a half-range in the URL.
+    """
+    chips: List[Dict[str, Any]] = []
+    for key, value in query_params.items():
+        if key in _NON_CHIP_KEYS:
+            continue
+        if key == "ukAmended":
+            label = _UK_AMENDED_CHIP_LABELS[value]
+            display_value: Any = None
+        else:
+            label = key
+            display_value = value
+        if key in _YEAR_RANGE_KEYS and year_clear_link is not None:
+            remove_link = year_clear_link
+        else:
+            remove_link = replace_param_and_make_smart_link(query_params, key, None)
+        chips.append({
+            "key": key,
+            "label": label,
+            "value": display_value,
+            "remove_link": remove_link,
+        })
+    return chips
 
 
 def browse(request, type: str, year: Optional[str] = None, subject: Optional[str] = None, extent_segment: Optional[str] = None):
@@ -222,6 +408,10 @@ def search_results(request):
     if _has_invalid_params(request):
         return render(request, 'new_theme/advance_search/full_search.html')
     params = extract_query_params(request)
+    # Apply the EU-type invariant before the redirect check so a
+    # /search?type=ukpga&ukamended=true URL canonicalises to /ukpga, never
+    # /ukpga?ukamended=true. The helper applies it again redundantly.
+    enforce_uk_amended_invariant(params)
     browse_params = normalize_params_for_browse(params)
     browse_url = build_browse_url_if_possible(browse_params)
     if browse_url:
@@ -241,21 +431,14 @@ def search_results_helper(request, query_params: SearchParams):
     elif current_type == "all":
         query_params.pop("type", None)
 
-    # Rename text→q only for API call, never mutate query_params
-    api_params = query_params.copy()
-    if "text" in api_params:
-        api_params["q"] = api_params.pop("text")
+    # Single normalisation boundary for the EU-type invariant: applied here
+    # after path params have been merged into the dict, before API calls,
+    # link generation, active-filter construction, or template context.
+    enforce_uk_amended_invariant(query_params)
 
-    api_data = basic_search(api_params)
+    api_data = from_api_response(basic_search(to_api_request(query_params)))
     meta = api_data["meta"]
-    # Template renders active-filter chips from meta.query; keep keys aligned
-    # with query_params (and modified_query_links) so removal links resolve.
-    if "q" in meta.get("query", {}):
-        meta["query"]["text"] = meta["query"].pop("q")
     documents_data = api_data["documents"]
-
-    total_count_by_type = sum(item["count"] for item in meta.get("counts", {}).get("byType", []))
-    total_count_by_year = sum(item["count"] for item in meta.get("counts", {}).get("byYear", []))
 
     current_page = meta.get("page", 1)
     total_pages = meta.get("totalPages", 1)
@@ -266,15 +449,16 @@ def search_results_helper(request, query_params: SearchParams):
     modified_query_links = {k: replace_param_and_make_smart_link(query_params, k, None) for k in query_params.keys()}
 
     # A year range lands in query_params as startYear/endYear (or one of them),
-    # not "year". Give the template a single "year" entry that clears every
-    # year alias so the sidebar's "All years" link and any chip-remove action
-    # fully escape the range.
-    if any(k in query_params for k in ("year", "startYear", "endYear")):
+    # not "year". Compute a single link that clears every year alias so the
+    # sidebar's "All years" link and any year chip's remove action fully
+    # escape the range — otherwise removing one half would leave the other.
+    year_clear_link: Optional[str] = None
+    if any(k in query_params for k in _YEAR_RANGE_KEYS):
         clear_year = query_params.copy()
         for field in ("year", "startYear", "endYear", "page", "pageSize"):
             clear_year.pop(field, None)
         year_clear_link = make_smart_link(clear_year)
-        for field in ("year", "startYear", "endYear"):
+        for field in _YEAR_RANGE_KEYS:
             modified_query_links[field] = year_clear_link
 
     base_query = request.GET.copy()
@@ -302,15 +486,17 @@ def search_results_helper(request, query_params: SearchParams):
 
     default_pagesize = query_params.get("pageSize", 20)
 
+    by_type_rows = meta.get("counts", {}).get("byType", [])
+    type_filter_groups = _build_type_filter_groups(by_type_rows, query_params, single_type)
+    active_filters = _build_active_filters(query_params, year_clear_link)
+
     grouped_by_decade = False
-    if len(meta.get("counts", {}).get("byType", [])) == 1:
+    if len(type_filter_groups) == 1:
         grouped_by_decade = group_by_decade(meta["counts"]["byYear"], single_type)
         for year_list in grouped_by_decade.values():
             for item in year_list:
                 item["link"] = replace_param_and_make_smart_link(query_params, "year", item["year"])
 
-    for byType in meta.get("counts", {}).get("byType", []):
-        byType["link"] = replace_param_and_make_smart_link(query_params, "type", to_short_type(byType["type"]))
     for byYear in meta.get("counts", {}).get("byYear", []):
         byYear["link"] = replace_param_and_make_smart_link(query_params, "year", byYear["year"])
     for byInitial in meta.get("counts", {}).get("bySubjectInitial", []):
@@ -355,8 +541,6 @@ def search_results_helper(request, query_params: SearchParams):
         "total_pages": total_pages,
         "current_subject": current_subject,
         "subject_heading": subject_heading,
-        "total_count_by_type": total_count_by_type,
-        "total_count_by_year": total_count_by_year,
         "modified_query_links": modified_query_links,
         "query_params": f"?{base_query_str}" if base_query_str else "",
         "query_param": query_params,
@@ -372,7 +556,10 @@ def search_results_helper(request, query_params: SearchParams):
         "all_lowercase_letters": string.ascii_lowercase,
         "default_pagesize": default_pagesize,
         "type_label_plural": get_type_label(single_type) if single_type else "documents",
-        "type_made_verb": get_first_version(single_type) if single_type else "documents"
+        "type_made_verb": get_first_version(single_type) if single_type else "documents",
+        "type_filter_groups": type_filter_groups,
+        "active_filters": active_filters,
+        "query_param_ui": to_ui_params(query_params),
     }
 
     return render(request, "new_theme/search_result/search_result.html", context)


### PR DESCRIPTION
## Summary
- Adds a `ukamended` URL parameter (true/false) for EU types (`eur`, `eudn`, `eudr`, `eudecn`), surfaced as sub-entries under each EU type in the left "By type" facet and as a removable chip in the active-filter bar.
- The filter is only meaningful for EU-origin types; navigating to a non-EU type clears `ukamended` (invariant enforced in `normalize_params_for_browse`).
- Sidebar uses long-form labels ("Regulations originating from the EU that are amended by the UK"); chips use short form ("Amended by UK legislation").
- When `ukAmended` is active, the type-facet group collapses to the single matching sub-entry, since the API can't return reliable counts for the parent or opposite sub-entry in that mode.
- Current type-facet entries render as inert `<span>` with `aria-current="page"` on the `<li>`, not as self-referential links.
- Year-range chip remove links now clear the whole range (`startYear` + `endYear` together), reusing the existing `year_clear_link`.

## Test plan
- [x] `python manage.py test` — full suite green (206 tests)
- [x] `/eur` shows parent + amended/not-amended sub-entries; counts add up (3683 + 121172 = 124855)
- [x] `/eur?ukamended=true` collapses to one inert entry; chip "Amended by UK legislation" with remove link to `/eur`
- [x] `/eur?ukamended=false` mirrors the above with "Not amended" wording
- [x] `/eudn` shows the three-entry pattern with "Decisions" wording
- [x] `/eudr` shows only the parent row (Directives don't have a `ukAmended` dimension in the underlying data; parity with legacy `legislation.gov.uk/eudr?ukamended=true`)
- [x] `/eur/1990-2010` year-range chips' remove links both point to `/eur` (whole range cleared)
- [x] Type-change invariant: navigating from `/eur?ukamended=true` to another type strips `ukamended`