### PR TITLE
Hide enacted/made version from timeline when other versions exist

### DIFF
--- a/docs/adr/2026-05-18-timeline-enacted-made-visibility.md
+++ b/docs/adr/2026-05-18-timeline-enacted-made-visibility.md
@@ -1,0 +1,165 @@
+# ADR: Timeline changes — enacted/made visibility and data model
+
+**Date:** 2026-05-18
+**Status:** Proposed
+**Deciders:** Jim Mangiafico (implementing); change requested by UX/editorial team
+
+## Context
+
+The timeline component shows all available versions of a legislation document, ordered chronologically. Currently, the enacted/made version always appears on the timeline as "the original version" when it exists, regardless of how many other versions are present. The `TimelineData` structure reflects this with a dedicated `original` field, separate from `historical` and `current`.
+
+The UX team wants to experiment with removing the enacted/made version from the timeline when other (dated) versions exist. The motivation is that the enacted/made version is qualitatively different from dated versions — it represents the state of the document upon enactment, which may never have been in force and may never have been the law — and its presence on the timeline alongside amendment dates is potentially confusing to users.
+
+At the same time, the UX team wants every document's "most recent version" view to show a timeline. For documents that have only one version (the enacted/made version), that version *is* the most recent version, so it must appear on the timeline to satisfy this requirement.
+
+These two goals create a specific interaction when a user navigates to the enacted/made version of a document that has other versions: the enacted/made version would not be on the timeline, which means the version being viewed would not appear on the timeline. Showing a timeline that does not include the version being viewed would be disorienting, so the timeline must be hidden entirely in that case.
+
+Additionally, the UX team has decided that the timeline should not appear on Table of Contents (ToC) pages at all. Currently, the ToC view calls `make_timeline_data()` and passes the result to the template, so ToC pages show the same timeline as document and fragment pages. The rationale for removing it is that the ToC is a navigation surface, not a reading surface — version context belongs on the document and fragment views where the user is actually reading legislation content.
+
+### Current behaviour
+
+- `_make_timeline_data()` always includes the original (enacted/made) version as `timeline['original']`, a dedicated field separate from `historical` and `current`.
+- The timeline section always renders when timeline data is present.
+- `single_version` disables the expand/collapse control but still shows the timeline summary.
+- The template has separate rendering blocks for `original`, `historical` entries, and `current`.
+- The ToC view generates and renders timeline data identically to document and fragment views.
+
+### Desired behaviour
+
+| Scenario | Timeline visible? | Enacted/made on it? |
+|---|---|---|
+| Enacted/made is the **only** version | Yes (non-expandable) | Yes (as `current`) |
+| Multiple versions exist, viewing enacted/made | **No** (section hidden) | N/A |
+| Multiple versions exist, viewing any other version | Yes | **No** |
+
+**Invariant:** the user never sees a timeline that omits the version they are currently viewing.
+
+## Decision
+
+Three changes — two behavioural and one structural:
+
+### 1. Enacted/made visibility rules
+
+Modify `_make_timeline_data()` in `lgu2/util/timeline.py` to implement the new visibility rules. The function's return type changes from `TimelineData` to `Optional[TimelineData]`, returning `None` when the timeline should be hidden.
+
+- **Multiple versions exist and the user is viewing the enacted/made version:** return `None`. The caller passes `None` to the template context, and the existing `{% if timeline %}` guard in `document.html` suppresses the entire timeline section.
+
+- **Multiple versions exist and the user is not viewing the enacted/made version:** exclude the enacted/made version from the timeline entirely. The timeline shows only dated and prospective versions.
+
+- **Only one version exists (the enacted/made version):** the enacted/made version appears on the timeline as `current`. The timeline renders with a single non-expandable entry.
+
+### 2. Remove the timeline from ToC pages
+
+The ToC view stops generating timeline data. The `make_timeline_data()` call in `views/toc.py` is removed, and no `timeline` key is passed to the template context. The timeline include in `toc.html` is currently unconditional (unlike `document.html`, which has an `{% if timeline %}` guard), so the include must also be removed from the ToC template.
+
+The `make_timeline_data` function's `target` parameter currently accepts `'toc'` to generate ToC-specific links. With no ToC caller, `'toc'` is no longer a supported value and is removed from the parameter's documented options. The URL-building logic itself is unchanged — it still constructs route names dynamically from the `target` string — but no caller passes `'toc'` any more.
+
+### 3. Remove the `original` field from `TimelineData`
+
+The dedicated `original` field on `TimelineData` was justified when the enacted/made version always appeared on the timeline alongside dated versions and needed distinct structural treatment. Under the new rules, this is no longer the case: the enacted/made version either *is* the current entry (when it's the sole version) or it is absent from the timeline entirely. It never coexists with other entries.
+
+The `TimelineData` structure changes from:
+
+```python
+class TimelineData(TypedDict):
+    original: Optional[TimelineEntry]
+    current: Optional[TimelineEntry]
+    historical: List[TimelineEntry]
+    viewing: TimelineEntry
+    pointInTime: Optional[date]
+    single_version: bool
+```
+
+to:
+
+```python
+class TimelineData(TypedDict):
+    entries: List[TimelineEntry]   # all versions before the latest, in chronological order
+    current: TimelineEntry         # the latest version — always visible, even when collapsed
+    viewing: TimelineEntry         # whichever entry corresponds to the version being viewed
+    pointInTime: Optional[date]
+    single_version: bool
+```
+
+The three-bucket model (`original` / `historical` / `current`) collapses to two: `entries` (everything before the latest) and `current` (the latest, which gets special presentation treatment — it remains visible when the timeline is collapsed).
+
+When the enacted/made version is the sole version, it becomes `current`. Its `label` field (`'enacted'`, `'made'`, `'created'`, `'adopted'`) tells the template how to render it — "as enacted on [date]" rather than "from [date]". Since Django templates cannot access Python sets like `_first` in `version.py`, the template uses literal label checks (e.g. `{% if current.label == 'enacted' or current.label == 'made' or current.label == 'created' or current.label == 'adopted' %}`) to distinguish enacted/made entries from dated ones. All four labels must be covered.
+
+### Why restructure the data model alongside the visibility change
+
+The visibility change alone could be implemented by nulling out the existing `original` field when other versions are present. But the `original` field would then be non-`None` only when it's the sole version — in which case it's also the current/latest. A field that is either `None` or redundant with `current` is dead weight in the data model and a source of confusion for future work on the timeline.
+
+Removing it now, while the enacted/made semantics are actively being reworked, is the natural time to clean up the structure. It also simplifies the template from three distinct rendering blocks to a loop over `entries` plus a dedicated block for `current`.
+
+### Why handle visibility in `_make_timeline_data` rather than in views or templates
+
+- The timeline module already owns the decision of which entries appear and how they are structured. Adding visibility rules here keeps timeline logic in one place.
+- Views already pass `timeline` through to the template without introspection; they do not need to learn about enacted/made semantics.
+- The template already handles `None` timeline data via `{% if timeline %}`.
+
+## Details
+
+### Files changed
+
+**`lgu2/util/timeline.py`**
+- Replace the `TimelineData` TypedDict: remove `original` and `historical`; replace optional `current` with required `current`; add `entries` as described above.
+- `make_timeline_data` return type: `TimelineData` → `Optional[TimelineData]`.
+- `_make_timeline_data` return type: same change.
+- Rewrite the entry-extraction logic:
+  1. Pop and hold aside the enacted/made label from the front of the versions list if present (so it doesn't become an `entries` item or `current`).
+  2. If no versions remain (the enacted/made label was the only version): the held-aside version becomes `current`.
+  3. If other versions remain: the last becomes `current`, the rest become `entries`. The held-aside enacted/made version is discarded.
+  4. If the user is viewing the enacted/made version and other versions exist: return `None`.
+
+**`lgu2/templates/new_theme/document/timeline.html`**
+- Replace the three separate rendering blocks (`original`, `historical` loop, `current`) with a single loop over `entries` plus a dedicated block for `current`.
+- The summary section adapts: when `current.label` is in the enacted/made set, render "the original version" / "as enacted on"; otherwise render "the current version" / "from" as before.
+
+**`lgu2/views/toc.py`**
+- Remove the `make_timeline_data` call and the `timeline` import.
+- No `timeline` key in the template context.
+
+**`lgu2/templates/new_theme/document/toc.html`**
+- Remove the `{% include "new_theme/document/timeline.html" %}` line (currently unconditional at line 33).
+
+**`lgu2/tests/util/test_timeline.py`**
+- Add test: single enacted version → timeline returned, `current.label == 'enacted'`, `entries` is empty, `single_version` is `True`.
+- Add test: multiple versions, viewing enacted → `None` returned.
+- Add test: multiple versions, viewing dated version → timeline returned, enacted excluded, `entries` contains intermediate versions.
+- Add test: exactly two versions (enacted + one date) → timeline returned, `entries` is empty, `current` is the date, `single_version` is `True`.
+- Remove `TocTimelineTests` class (ToC no longer uses the timeline).
+- Update existing tests to use the new `entries`/`current` structure instead of `original`/`historical`/`current`.
+
+### Edge cases
+
+**Document with exactly two versions (enacted + one date):** the enacted version is excluded, leaving just the dated version as `current` with an empty `entries` list. `single_version` is `True`, so the expand control is disabled. This satisfies the "most recent version always has a timeline" requirement.
+
+**Prospective-only documents:** a document with versions `['enacted', 'prospective']` viewing `prospective` will show a timeline with just the prospective entry as `current`. The enacted version is excluded. This follows the same rule as any other multi-version case.
+
+**Fragment views:** the same `make_timeline_data` function serves both document and fragment views. The enacted/made visibility rules apply uniformly — the timeline semantics do not vary between these two view types.
+
+**Template rendering of enacted-as-current:** when `current.label` is `'enacted'`, `'made'`, `'created'`, or `'adopted'`, the template renders "as [label] on [date]" instead of "from [date]". This reuses the label-detection logic already present in the template's original block, now applied to `current` via literal checks against all four labels.
+
+**Semantic shift of `single_version`:** this field currently means "one version exists in total." Under the new rules, its meaning shifts to "one version is visible on the timeline." For example, a document with versions `['enacted', '2024-01-01']` has two versions, but the timeline shows only `2024-01-01`, so `single_version` is `True`. This is the correct semantics for the template — it controls whether the expand/collapse control is disabled — but the name now describes visible entry count rather than total version count. A rename (e.g. `single_entry`) could clarify this, but is deferred to avoid unnecessary churn.
+
+### What this ADR does not cover
+
+- **How users navigate to the enacted/made version** when it is not on the timeline. The UX team will provide a separate mechanism (likely a link elsewhere on the page). That work is independent of this change.
+- **Point-in-time interaction.** The `pointInTime` field on the timeline is unaffected. When viewing a dated version with a point-in-time marker, the timeline renders as before, just without the enacted/made entry.
+
+## Consequences
+
+- The timeline data model becomes simpler: two buckets (`entries` + `current`) instead of three (`original` + `historical` + `current`).
+- The template simplifies from three distinct rendering blocks to a loop plus one block.
+- The enacted/made version page for multi-version documents loses its timeline. Users must reach the enacted/made version via whatever alternative navigation the UX team provides.
+- Every "most recent version" view on document and fragment pages retains a timeline, satisfying the UX requirement.
+- ToC pages no longer show a timeline. The `'toc'` target path through `make_timeline_data` is removed.
+- Future timeline changes (additional entry types, different ordering, new presentation rules) work against a cleaner two-bucket model.
+
+## Alternatives considered
+
+- **Keep the `original` field, set it to `None` when other versions exist.** Less code churn, but leaves a field in the data model that is either `None` or redundant with `current`. The structural mismatch would need cleaning up eventually; doing it now while the semantics are changing is cheaper.
+- **Hide timeline in the template via a CSS class or conditional.** Would work but splits timeline visibility logic between Python (which entries to show) and templates (whether to show the section). Keeping it in one place is simpler.
+- **Add a `visible` boolean to `TimelineData` instead of returning `None`.** Marginally more explicit, but introduces a field that every template consumer must check, when `None` already conveys "no timeline" naturally.
+- **Handle in views rather than in `_make_timeline_data`.** Would require each view (document, fragment, ToC) to independently implement the same enacted/made visibility check. Violates the existing pattern where timeline logic is centralised.
+- **Add a boolean `enacted` field to `TimelineEntry`.** Would allow templates to style enacted/made entries differently. Deferred: the label already carries this information (via the `_first` set in `version.py`), and no design currently calls for distinct styling. Easy to add later if needed.

--- a/lgu2/static/new_theme/default_v4.css
+++ b/lgu2/static/new_theme/default_v4.css
@@ -431,13 +431,13 @@ body:not(:-moz-handler-blocked) fieldset {
   background: url('images/dated-version.png') no-repeat 0.25em 0.575em;
   background-size: 1.25em;
 }
-:root .legislation .legislation-content aside > div.as-enacted-formats,
-:root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted-formats {
-  background: url('images/timeline-version.png') no-repeat 0.35em 0.65em;
-  background-size: 1em;
+:root .legislation .legislation-content aside > div.as-enacted,
+:root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted {
+  background: url('images/as-enacted.png') no-repeat 0.25em 0.575em;
+  background-size: 1.25em;
 }
-:root .legislation .legislation-content aside > div.as-enacted-formats.pdf,
-:root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted-formats.pdf {
+:root .legislation .legislation-content aside > div.as-enacted.pdf,
+:root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted.pdf {
   background: url('images/kpv-pdf.png') no-repeat 0.05em 0.575em;
   background-size: 1.5em;
 }
@@ -475,11 +475,6 @@ body:not(:-moz-handler-blocked) fieldset {
 :root[colour-scheme="light"] .legislation .legislation-content aside > div.associated-documents {
   background: url('images/associated-documents.png') no-repeat 0.15em 0.5em;
   background-size: 1.45em;
-}
-:root .legislation .legislation-content aside > div.as-enacted,
-:root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted {
-  background: url('images/as-enacted.png') no-repeat 0.25em 0.575em;
-  background-size: 1.25em;
 }
 :root .legislation .legislation-content aside details.other-formats h3:before,
 :root[colour-scheme="light"] .legislation .legislation-content aside details.other-formats h3:before {
@@ -802,11 +797,11 @@ body:not(:-moz-handler-blocked) fieldset {
   background: url('images/dated-version-dm.png') no-repeat 0.25em 0.575em;
   background-size: 1.25em;
 }
-:root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted-formats {
-  background: url('images/timeline-version-active.png') no-repeat 0.35em 0.65em;
-  background-size: 1em;
+:root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted {
+  background: url('images/as-enacted-dm.png') no-repeat 0.25em 0.575em;
+  background-size: 1.25em;
 }
-:root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted-formats.pdf {
+:root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted.pdf {
   background: url('images/kpv-pdf-dm.png') no-repeat 0.05em 0.575em;
   background-size: 1.5em;
 }
@@ -837,10 +832,6 @@ body:not(:-moz-handler-blocked) fieldset {
 :root[colour-scheme="dark"] .legislation .legislation-content aside > div.associated-documents {
   background: url('images/associated-documents-dm.png') no-repeat 0.15em 0.5em;
   background-size: 1.45em;
-}
-:root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted {
-  background: url('images/as-enacted-dm.png') no-repeat 0.25em 0.575em;
-  background-size: 1.25em;
 }
 :root[colour-scheme="dark"] .legislation .legislation-content > div .legislation-ftr aside h3.up-to-date {
   background-image: url('images/up-to-date-dm.png');
@@ -1759,7 +1750,7 @@ summary::-webkit-details-marker {
   border: 0;
 }
 .scrollbar-controls button {
-  width: 2.85rem;
+  width: 2.65rem;
   position: relative;
   margin: 0 0.9375rem 0 0.1rem;
   padding: 0;
@@ -1808,7 +1799,7 @@ summary::-webkit-details-marker {
 }
 .scrollbar-controls .drag-strip {
   position: relative;
-  width: 100%;
+  flex-grow: 1;
   height: 2.5rem;
   padding: 0 0 0.0625rem 0;
 }
@@ -3109,7 +3100,7 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   border: 0;
 }
 .search-results .dataset .scrollbar button {
-  width: 2.85rem;
+  width: 2.65rem;
   position: relative;
   margin: 0 0.9375rem 0 0.1rem;
   padding: 0;
@@ -3158,7 +3149,7 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
 }
 .search-results .dataset .scrollbar .drag-strip {
   position: relative;
-  width: 100%;
+  flex-grow: 1;
   height: 2.5rem;
   padding: 0 0 0.0625rem 0;
 }
@@ -5888,34 +5879,37 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
 .legislation .timeline:has(details:not([open])):has(.versions li[aria-current="page"] .point-in-time):has(.versions li[aria-current="page"] .previous-point-in-time) summary .version:after {
   border-top: 0.5em dashed var(--timelineVersionActive);
 }
+.legislation .timeline:has(details:not([open])):has(.versions li[aria-current="page"] .point-in-time):has(.versions li[aria-current="page"] .previous-point-in-time) summary .version:before {
+  border-top-color: transparent;
+}
+.legislation .timeline:has(details:not([open])):has(.versions li[aria-current="page"] .point-in-time):has(.versions li[aria-current="page"] .previous-point-in-time) summary .version:after {
+  border-top: 0.5em dashed var(--timelineVersionActive);
+}
+.legislation .timeline:has(details:not([open])):has(.versions li[aria-current="page"] .point-in-time):has(.versions li:last-of-type[aria-current="page"] .previous-point-in-time) summary .version:before {
+  border-top-color: var(--timelineVersionActive);
+}
+.legislation .timeline:has(details:not([open])):has(.versions li[aria-current="page"] .point-in-time):has(.versions li:last-of-type[aria-current="page"] .previous-point-in-time) summary .version:after {
+  border-top: 0.5em dashed var(--timelineVersionActive);
+}
 .legislation .timeline:has(details:not([open])):has(.versions li[aria-current="page"] .point-in-time) summary .date {
   display: none;
 }
-.legislation .timeline:has(details:not([open])):has(.versions li:first-of-type[aria-current="page"]) summary .version:before,
+.legislation .timeline:has(details:not([open])):has(.versions li:first-of-type[aria-current="page"]) summary .version:before {
+  border-top-color: transparent;
+}
 .legislation .timeline:has(details:not([open])):has(.versions li:first-of-type[aria-current="page"]) summary .version:after {
-  border-top-color: transparent;
-}
-.legislation .timeline:has(details:not([open])):has(.versions li:first-of-type[aria-current="page"]) summary .date:before {
-  background: var(--timelineVersionActive) var(--timelineEnactedVersionIconActive);
-  background-size: 55%;
-}
-.legislation .timeline:has(details:not([open])):has(.versions li:nth-of-type(2)[aria-current="page"]) summary .version:before,
-.legislation .timeline:has(details:not([open])):has(.versions li:nth-of-type(2)[aria-current="page"]) summary .version:after {
-  border-top-color: transparent;
-}
-.legislation .timeline:has(details:not([open])):has(.versions li:nth-of-type(2)[aria-current="page"]):has(.versions li:nth-of-type(3)) summary .version:before {
-  border-top-color: transparent;
-}
-.legislation .timeline:has(details:not([open])):has(.versions li:nth-of-type(2)[aria-current="page"]):has(.versions li:nth-of-type(3)) summary .version:after {
   border-top-color: var(--timelineVersion);
 }
-.legislation .timeline:has(details:not([open])):has(.versions li:nth-of-type(2)[aria-current="page"]):has(.versions li[aria-current="page"] .point-in-time:not(.previous-point-in-time)) summary .version:before {
+.legislation .timeline:has(details:not([open])):has(.versions li:first-of-type[aria-current="page"]):has(.versions li:last-of-type[aria-current="page"]) summary .version:after {
+  border-top-color: transparent;
+}
+.legislation .timeline:has(details:not([open])):has(.versions li:first-of-type[aria-current="page"]):has(.versions .previous-point-in-time) summary .version:before {
+  border-top-color: var(--transparent);
+}
+.legislation .timeline:has(details:not([open])):has(.versions li:first-of-type[aria-current="page"]):has(.versions .previous-point-in-time) summary .version:after {
   border-top-color: var(--timelineVersionActive);
 }
-.legislation .timeline:has(details:not([open])):has(.versions li:last-of-type[aria-current="page"]:nth-of-type(n+3)) summary .version:before {
-  border-top-color: var(--timelineVersionActive);
-}
-.legislation .timeline:has(details:not([open])):has(.versions li:last-of-type[aria-current="page"]:nth-of-type(n+3)) summary .version:after {
+.legislation .timeline:has(details:not([open])):has(.versions li:last-of-type[aria-current="page"]) summary .version:after {
   border-top-color: transparent;
 }
 .legislation .timeline .versions .scrollbar {
@@ -6316,7 +6310,7 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   width: 0.65rem;
   height: 0.225em;
 }
-.legislation .legislation-content > aside > div.as-enacted-formats p {
+.legislation .legislation-content > aside > div.as-enacted p {
   height: 2.25rem;
   padding: 0.15rem 0 0.15rem 2rem;
   display: table-cell;
@@ -6600,6 +6594,10 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
 .legislation .legislation-content > div .legislation-text > ol > li li {
   margin: 0.25em 0 0 0;
 }
+.legislation .legislation-content > div .legislation-text > ol > li:has(h3) > .prefix {
+  font-weight: 500;
+  line-height: 1.5rem;
+}
 .legislation .legislation-content > div .legislation-text .prefix {
   position: absolute;
   margin: 0 0 0 -8em;
@@ -6609,6 +6607,9 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
 .legislation .legislation-content > div .legislation-text .prefix .wrapper {
   display: inline-block;
   line-height: 1.2em;
+}
+.legislation .legislation-content > div .legislation-text .prefix .marker .annotation {
+  line-height: 1.5em;
 }
 .legislation .legislation-content > div .legislation-text iframe {
   width: 100%;
@@ -7274,13 +7275,26 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
 .legislation .legislation-content > div .status-panel details[open] > div {
   max-height: 25vh;
   overflow-y: scroll;
-  padding: 0 1rem;
+  padding: 0;
   scroll-timeline: --scroll;
 }
+.legislation .legislation-content > div .status-panel details[open] > div h3 {
+  font-size: 1.05rem;
+  margin: 0 0 0.25rem 0;
+  padding: 0.65rem 1rem;
+  background: var(--altBg);
+}
+.legislation .legislation-content > div .status-panel details[open] > div h4 {
+  font-size: 1rem;
+  padding: 0.25rem 1rem 0.15rem 1rem;
+}
 .legislation .legislation-content > div .status-panel details[open] > div ul {
-  padding: 0.75rem 0;
+  padding: 0.35rem 1rem 0.75rem 1rem;
   margin: 0;
   list-style: none;
+}
+.legislation .legislation-content > div .status-panel details[open] > div ul:first-child {
+  padding: 0.75rem 0;
 }
 .legislation .legislation-content > div .status-panel details[open] > div ul * {
   font-family: "Roboto";
@@ -7345,8 +7359,12 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   bottom: 0;
   width: 100%;
 }
-.legislation:has(.previous-point-in-time, .not-commenced) .legislation-content > aside > div.in-force {
-  border-top: 0.125rem dashed var(--subtleBorder);
+.legislation:has(.previous-point-in-time, .not-commenced) {
+  /*
+            .legislation-content > aside > div.in-force {
+				border-top: 0.125rem dashed var(--subtleBorder);
+			}
+		*/
 }
 .legislation:has(.previous-point-in-time, .not-commenced) .legislation-content > div .legislation-text:has(> p) > ol,
 .legislation:has(.previous-point-in-time, .not-commenced) .legislation-content > div .legislation-text:has(> p) > ul {
@@ -7847,6 +7865,16 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
 }
 @media print and (orientation: portrait), screen and (min-width: calc(768px)) and (max-width: calc(1024px - 1px)) {
   /* timeline and metadata on same row */
+  main.legislation:has(.timeline details:not([open])) {
+    /*
+				&:has(.previous-point-in-time, .not-commenced) {
+					.legislation-content > aside > div.in-force {
+						p:first-of-type {border-top: 0.125rem dashed var(--subtleBorder)}
+						+ .in-force p:first-of-type {border-color: var(--alert); padding: 0.55em 0 0.55rem 2em}
+					}
+                }
+			*/
+  }
   main.legislation:has(.timeline details:not([open])) .timeline {
     margin: 0 1rem;
     position: absolute;
@@ -7975,25 +8003,13 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   main.legislation:has(.timeline details:not([open])) .legislation-content > aside:first-of-type > div.not-up-to-date p:first-of-type {
     background-position: 0.05rem 0.3rem;
   }
-  main.legislation:has(.timeline details:not([open])) .legislation-content > aside:first-of-type > div.as-enacted-formats,
-  main.legislation:has(.timeline details:not([open])) .legislation-content > aside:first-of-type > div.as-enacted-formats.pdf {
-    background-position: 1.25em 0.55em;
+  main.legislation:has(.timeline details:not([open])) .legislation-content > aside:first-of-type > div.as-enacted.pdf {
+    background-position: 0.75em 0.55em;
     flex-grow: unset;
   }
-  main.legislation:has(.timeline details:not([open])) .legislation-content > aside:first-of-type > div.as-enacted-formats p,
-  main.legislation:has(.timeline details:not([open])) .legislation-content > aside:first-of-type > div.as-enacted-formats.pdf p {
+  main.legislation:has(.timeline details:not([open])) .legislation-content > aside:first-of-type > div.as-enacted.pdf p {
     min-height: 2.25rem;
     padding: 0.5rem 0 0.15rem 2rem;
-  }
-  main.legislation:has(.timeline details:not([open])) .legislation-content > aside:first-of-type > div.as-enacted-formats.pdf {
-    background-position: 0.75em 0.55em;
-  }
-  main.legislation:has(.timeline details:not([open])):has(.previous-point-in-time, .not-commenced) .legislation-content > aside > div.in-force p:first-of-type {
-    border-top: 0.125rem dashed var(--subtleBorder);
-  }
-  main.legislation:has(.timeline details:not([open])):has(.previous-point-in-time, .not-commenced) .legislation-content > aside > div.in-force + .in-force p:first-of-type {
-    border-color: var(--alert);
-    padding: 0.55em 0 0.55rem 2em;
   }
   main.legislation:has(.timeline details:not([open])):has(.prospective[aria-current="page"]) .legislation-content > aside > div.in-force p:first-of-type {
     border-top: 0.125rem dashed var(--subtleBorder);
@@ -8360,24 +8376,6 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   main.legislation .timeline:has(> details[open]) details .versions ol li:has(> div):before {
     border: 0.2rem solid var(--disabledButtonBorder);
   }
-  main.legislation .timeline:has(> details[open]) details .versions ol li.consolidated:before {
-    top: 1.5rem;
-  }
-  main.legislation .timeline:has(> details[open]) details .versions ol li.consolidated a {
-    padding: 1.5rem 0 1rem 2rem;
-  }
-  main.legislation .timeline:has(> details[open]) details .versions ol li.consolidated a:before {
-    content: "";
-    display: block;
-    height: 2rem;
-    width: 1rem;
-    position: absolute;
-    left: 0.25rem;
-    top: -1rem;
-    background-image: url('images/timeline-break.png');
-    background-repeat: no-repeat;
-    background-size: 1rem;
-  }
   main.legislation .timeline:has(> details[open]) details .versions ol li:has(~ [aria-current="page"]):not(:first-of-type, :last-of-type):after {
     background: var(--bg);
   }
@@ -8387,9 +8385,51 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   main.legislation .timeline:has(> details[open]) details .versions ol li:has(~ [aria-current="page"]):first-of-type:has(> div):before {
     background: transparent;
   }
-  main.legislation .timeline:has(> details[open]) details .versions ol li:first-of-type,
   main.legislation .timeline:has(> details[open]) details .versions ol li:last-of-type {
+    padding: 0;
     border-color: transparent;
+  }
+  main.legislation .timeline:has(> details[open]) details .versions ol li:last-of-type a {
+    padding: 0 0 0 1.25rem;
+  }
+  main.legislation .timeline:has(> details[open]) details .versions ol li.consolidated:before {
+    z-index: 1;
+    top: 1.75rem;
+  }
+  main.legislation .timeline:has(> details[open]) details .versions ol li.consolidated a {
+    padding: 1.5rem 0 1rem 1.25rem;
+  }
+  main.legislation .timeline:has(> details[open]) details .versions ol li.consolidated a:before {
+    content: "";
+    top: -0.25rem;
+    left: -0.2rem;
+    height: 2rem;
+    position: absolute;
+    background: var(--modalTimelinePast);
+    width: 0.2rem;
+  }
+  main.legislation .timeline:has(> details[open]) details .versions ol li.consolidated a:after {
+    content: "";
+    display: block;
+    height: 2rem;
+    width: 1rem;
+    position: absolute;
+    left: -0.6rem;
+    top: -0.75rem;
+    background-image: url(images/timeline-break.png);
+    background-repeat: no-repeat;
+    background-size: 1rem;
+  }
+  main.legislation .timeline:has(> details[open]) details .versions ol li.consolidated .explanation {
+    margin: -0.75rem 0 0.75rem 1.25rem;
+    font-style: italic;
+    font-weight: 300;
+  }
+  main.legislation .timeline:has(> details[open]) details .versions ol li.consolidated:last-of-type a {
+    padding: 1.5rem 0 0 1.25rem;
+  }
+  main.legislation .timeline:has(> details[open]) details .versions ol li.consolidated:last-of-type .explanation {
+    margin: 0.25rem 0 0.75rem 1.25rem;
   }
   main.legislation .timeline:has(> details[open]) details .versions a {
     color: var(--modalText);
@@ -8493,11 +8533,11 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   main.legislation .legislation-content > aside:has(.not-up-to-date) {
     border: 0.13rem dashed var(--warningBorder);
   }
-  main.legislation .legislation-content > aside > div.as-enacted-formats {
+  main.legislation .legislation-content > aside > div.as-enacted {
     display: table;
     width: -webkit-fill-available;
   }
-  main.legislation .legislation-content > aside > div.as-enacted-formats p {
+  main.legislation .legislation-content > aside > div.as-enacted p {
     padding: 0.25rem 0 0.25rem 2rem;
   }
   main.search-results .search-content > details > summary .close span {
@@ -9553,6 +9593,17 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     background-image: url('images/scrollable-timeline-break-inactive-dm.png');
     background-size: 100%;
   }
+  :root .legislation,
+  :root[colour-scheme="light"] .legislation,
+  :root[colour-scheme="dark"] .legislation {
+    /*
+                &:has(.previous-point-in-time, .not-commenced) {
+                    .legislation-content > aside > div.in-force {
+						border: 0.125rem dashed var(--lessSubtleBorder);
+					}
+                }
+			*/
+  }
   :root .legislation .legislation-content aside > div.language,
   :root[colour-scheme="light"] .legislation .legislation-content aside > div.language,
   :root[colour-scheme="dark"] .legislation .legislation-content aside > div.language {
@@ -9599,32 +9650,27 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     background-position: 0.7em 0.6em;
     background-size: 1.6em;
   }
-  :root .legislation .legislation-content aside > div.as-enacted-formats,
-  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted-formats,
-  :root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted-formats {
-    background-position: 0.85em 0.65em;
-    background-size: 1.1em;
+  :root .legislation .legislation-content aside > div.as-enacted,
+  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted,
+  :root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted {
+    background-position: 0.8em 0.65em;
+    background-size: 1.4em;
   }
-  :root .legislation .legislation-content aside > div.as-enacted-formats p,
-  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted-formats p,
-  :root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted-formats p {
-    padding: 0.5em 0.5em 0.35em 3em;
+  :root .legislation .legislation-content aside > div.as-enacted:has(a),
+  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted:has(a),
+  :root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted:has(a) {
+    border-color: var(--link);
   }
-  :root .legislation .legislation-content aside > div.as-enacted-formats:not(.pdf) a,
-  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted-formats:not(.pdf) a,
-  :root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted-formats:not(.pdf) a {
-    font-weight: 500;
-  }
-  :root .legislation .legislation-content aside > div.as-enacted-formats.pdf,
-  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted-formats.pdf,
-  :root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted-formats.pdf {
+  :root .legislation .legislation-content aside > div.as-enacted.pdf,
+  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted.pdf,
+  :root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted.pdf {
     background-position: 0.45em 0.6em;
     background-size: 1.8em;
   }
-  :root .legislation .legislation-content aside > div.as-enacted-formats.pdf:has(a),
-  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted-formats.pdf:has(a),
-  :root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted-formats.pdf:has(a) {
-    border-color: var(--link);
+  :root .legislation .legislation-content aside > div.as-enacted.pdf p,
+  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted.pdf p,
+  :root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted.pdf p {
+    padding: 0.5em 0.5em 0.35em 3em;
   }
   :root .legislation .legislation-content aside > div.extent,
   :root[colour-scheme="light"] .legislation .legislation-content aside > div.extent,
@@ -9717,17 +9763,6 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     background-position: 0.65em 0.5em;
     background-size: 1.5em;
   }
-  :root .legislation .legislation-content aside > div.as-enacted,
-  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted,
-  :root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted {
-    background-position: 0.8em 0.65em;
-    background-size: 1.4em;
-  }
-  :root .legislation .legislation-content aside > div.as-enacted:has(a),
-  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted:has(a),
-  :root[colour-scheme="dark"] .legislation .legislation-content aside > div.as-enacted:has(a) {
-    border-color: var(--link);
-  }
   :root .legislation .legislation-content aside > div:has(p).explanatory-notes,
   :root[colour-scheme="light"] .legislation .legislation-content aside > div:has(p).explanatory-notes,
   :root[colour-scheme="dark"] .legislation .legislation-content aside > div:has(p).explanatory-notes {
@@ -9740,11 +9775,6 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   :root[colour-scheme="dark"] .legislation .legislation-content aside > div:has(p).associated-documents {
     background-position: 0.55em 0.6em;
     background-size: 1.8em;
-  }
-  :root .legislation:has(.previous-point-in-time, .not-commenced) .legislation-content > aside > div.in-force,
-  :root[colour-scheme="light"] .legislation:has(.previous-point-in-time, .not-commenced) .legislation-content > aside > div.in-force,
-  :root[colour-scheme="dark"] .legislation:has(.previous-point-in-time, .not-commenced) .legislation-content > aside > div.in-force {
-    border: 0.125rem dashed var(--lessSubtleBorder);
   }
   :root .legislation:has(.prospective[aria-current="page"]) .legislation-content > aside:first-of-type > div,
   :root[colour-scheme="light"] .legislation:has(.prospective[aria-current="page"]) .legislation-content > aside:first-of-type > div,
@@ -10255,6 +10285,7 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     position: absolute;
     width: 2.5rem;
     height: 12.5rem;
+    z-index: 30;
   }
   main.legislation .timeline:has(> details[open]) > details > summary:hover,
   main.legislation .timeline:has(> details[open]) > details > summary:focus {
@@ -10296,8 +10327,8 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     flex-flow: row;
     overflow-x: auto;
     overflow-y: hidden;
-    margin: 0 16rem 0 2.5rem;
-    width: calc(100% - 18.5rem);
+    margin: 0 16rem;
+    width: calc(100% - 32rem);
     height: 12.5rem;
     background: var(--verySubtleBg);
   }
@@ -10308,10 +10339,10 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   main.legislation .timeline:has(> details[open]) .versions ol:before {
     content: "";
     background: var(--timelineVersion);
-    width: calc(var(--maxWidth) - 40.75rem);
+    width: calc(var(--maxWidth) - 20rem);
     height: 0.5rem;
     position: absolute;
-    margin: 6.05rem 0 0 20.25rem;
+    margin: 6.05rem 0 0 -6rem;
   }
   main.legislation .timeline:has(> details[open]) .versions ol:has(li:nth-of-type(2) .previous-point-in-time):before {
     width: calc(var(--maxWidth) - 44rem);
@@ -10323,8 +10354,14 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type[aria-current="page"]):before {
     background: var(--timelineVersionActive);
   }
-  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type:nth-of-type(2)):before {
-    display: none;
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type[aria-current="page"]):has(li:first-of-type > div):before {
+    background: var(--lessSubtleBorder);
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type[aria-current="page"]):has(li:first-of-type > div) li:first-of-type .version:after {
+    border-color: transparent;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type[aria-current="page"]):has(li:first-of-type > div) li.consolidated a:before {
+    left: -0.5rem;
   }
   main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type:nth-of-type(2)) li > a .version:before {
     border-color: transparent;
@@ -10419,11 +10456,14 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   }
   main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type {
     background: var(--verySubtleBg);
-    margin: 0 0.5rem 0 0;
+    margin: 0 0 0 -16rem;
+    z-index: 20;
+    position: absolute;
   }
   main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type > a,
   main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type > div {
-    width: 13.5rem;
+    padding: 2.05rem 0 0 2.4rem;
+    width: 16rem;
   }
   main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type > a .version:before,
   main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type > div .version:before,
@@ -10433,21 +10473,15 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   }
   main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type > a .date:before,
   main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type > div .date:before {
-    background: var(--bg) var(--timelineEnactedVersionIcon);
-    background-size: 55%;
+    background: var(--bg) var(--timelineVersionIcon);
+    background-size: 40%;
     width: 3.15rem;
     height: 3.15rem;
     border-radius: 50%;
     margin: -1.8rem auto 0.8rem auto;
   }
   main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type > div .date:before {
-    border: 0.2rem solid var(--subtleBorder);
-  }
-  main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type[aria-current="page"] > a .version:before {
-    border-color: transparent;
-  }
-  main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type[aria-current="page"] > a .version:after {
-    border-color: transparent;
+    border: 0.2rem solid var(--lessSubtleBorder);
   }
   main.legislation .timeline:has(> details[open]) .versions ol li:nth-of-type(2) > a .version:before,
   main.legislation .timeline:has(> details[open]) .versions ol li:nth-of-type(2) > div .version:before {
@@ -10456,7 +10490,7 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   main.legislation .timeline:has(> details[open]) .versions ol li:last-of-type {
     position: absolute;
     width: 16rem;
-    margin: 0 0 0 calc(var(--maxWidth) - 20.5rem);
+    margin: 0 0 0 calc(var(--maxWidth) - 34rem);
     background: var(--verySubtleBg);
   }
   main.legislation .timeline:has(> details[open]) .versions ol li:last-of-type > a {
@@ -10546,6 +10580,10 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   main.legislation .timeline:has(> details[open]) .versions ol li[aria-current="page"]:has(.point-in-time) + li .version:before {
     margin: 4rem 50% -4rem -3.75rem;
   }
+  main.legislation .timeline:has(> details[open]) .versions ol li[aria-current="page"]:has(.point-in-time):first-of-type > a {
+    padding: 2.05rem 5.5rem 0 2.9rem;
+    width: 21rem;
+  }
   main.legislation .timeline:has(> details[open]) .versions ol li:not([aria-current="page"]):hover > a,
   main.legislation .timeline:has(> details[open]) .versions ol li:not([aria-current="page"]):focus > a {
     color: var(--link);
@@ -10563,13 +10601,16 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     -moz-box-shadow: 0 0 0.375rem 0 var(--focusShadow);
     box-shadow: 0 0 0.375rem 0 var(--focusShadow);
     outline: 0;
-    background: var(--buttonBg) var(--timelineVersionIconHover);
+    background: var(--focusButtonBg) var(--timelineVersionIconHover);
     background-size: 40%;
   }
-  main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type:not([aria-current="page"]):hover > a .date:before,
-  main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type:not([aria-current="page"]):focus > a .date:before {
-    background: var(--buttonBg) var(--timelineEnactedVersionIconHover);
-    background-size: 55%;
+  main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type:not([aria-current="page"]) > a .version:after,
+  main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type:not([aria-current="page"]) > div .version:after {
+    border-color: var(--timelineVersionActive);
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type:not([aria-current="page"]) ~ :nth-of-type(2) > a .version:before,
+  main.legislation .timeline:has(> details[open]) .versions ol li:first-of-type:not([aria-current="page"]) ~ :nth-of-type(2) > div .version:before {
+    border-color: var(--timelineVersionActive);
   }
   main.legislation .timeline:has(> details[open]) .versions ol li[aria-current="page"]:not(:has(.point-in-time)) > a,
   main.legislation .timeline:has(> details[open]) .versions ol li[aria-current="page"]:not(:has(.point-in-time)) > div {
@@ -10593,10 +10634,6 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     background: var(--timelineVersionActive) var(--timelineVersionIconActive);
     background-size: 40%;
   }
-  main.legislation .timeline:has(> details[open]) .versions ol li[aria-current="page"]:first-of-type > a .date:before {
-    background: var(--timelineVersionActive) var(--timelineEnactedVersionIconActive);
-    background-size: 55%;
-  }
   main.legislation .timeline:has(> details[open]) .versions ol li[aria-current="page"] ~ li:not(:last-of-type ) > a .version:before,
   main.legislation .timeline:has(> details[open]) .versions ol li[aria-current="page"] ~ li:not(:last-of-type ) > div .version:before,
   main.legislation .timeline:has(> details[open]) .versions ol li[aria-current="page"] ~ li:not(:last-of-type ) > a .version:after,
@@ -10606,6 +10643,9 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   main.legislation .timeline:has(> details[open]) .versions ol li[aria-current="page"] ~ li:nth-of-type(2) > a .version:before,
   main.legislation .timeline:has(> details[open]) .versions ol li[aria-current="page"] ~ li:nth-of-type(2) > div .version:before {
     border-color: transparent;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol li[aria-current="page"] ~ li:nth-of-type(2) > a .version:before {
+    border-color: var(--timelineVersion);
   }
   main.legislation .timeline:has(> details[open]) .versions ol li.prospective > a .date:before {
     border-color: var(--alert);
@@ -10627,6 +10667,14 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     background: var(--repealed) var(--timelineRepealedVersionActive);
     background-size: 40%;
   }
+  main.legislation .timeline:has(> details[open]) .versions ol li.consolidated > a,
+  main.legislation .timeline:has(> details[open]) .versions ol li.consolidated > div {
+    padding: 2.05rem 0 0 2.5rem;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol li.consolidated > a .version:before,
+  main.legislation .timeline:has(> details[open]) .versions ol li.consolidated > div .version:before {
+    margin: 4rem 50% -4rem -2.5rem;
+  }
   main.legislation .timeline:has(> details[open]) .versions ol li.consolidated a:before {
     content: "";
     display: block;
@@ -10639,9 +10687,20 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     background-position: 0 0;
     background-repeat: no-repeat;
     position: absolute;
-    left: -0.8rem;
+    left: 1rem;
     top: calc(50% - (2.125rem / 2));
     z-index: 1;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol li.consolidated .explanation {
+    position: absolute;
+    width: 0.0625rem;
+    height: 0.0625rem;
+    padding: 0;
+    margin: -0.0625rem;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
   main.legislation .timeline:has(> details[open]) .versions ol li details:not([open]) summary {
     position: absolute;
@@ -10798,41 +10857,148 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   main.legislation .timeline:has(> details[open]) .versions ol li:last-of-type div {
     left: 0.5rem;
   }
-  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time) {
-    width: calc(100% - 22rem);
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type .point-in-time) {
+    margin: 0 16rem 0 22rem;
+    width: calc(100% - 38rem);
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type .point-in-time):before {
+    width: calc(var(--maxWidth) - 25rem);
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type .point-in-time) li:first-of-type {
+    margin: 0 0 0 -22rem;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type .point-in-time) li:first-of-type > a {
+    padding: 2.05rem 6.5rem 0 2.9rem;
+    width: 22rem;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type .point-in-time) li:first-of-type > a .version:after {
+    margin: 2.2rem -2rem 0 50%;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type .point-in-time) li:first-of-type > a .point-in-time {
+    right: 1rem;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type .point-in-time) li:last-of-type {
+    margin: 0 0 0 calc(var(--maxWidth) - 40rem);
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time):before {
+    width: calc(var(--maxWidth) - 33.25rem);
   }
   main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time) li:last-of-type {
-    width: 19.5rem;
-    margin: 0 0 0 calc(var(--maxWidth) - 24rem);
-  }
-  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time) li:last-of-type > a {
-    padding: 2.05rem 9rem 0 0;
-    width: 21.5rem;
-  }
-  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time) li:last-of-type > a .version:before {
-    margin: 4rem 50% -4rem 0;
-  }
-  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time) li:last-of-type > a .point-in-time {
-    right: 1.35rem;
-  }
-  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time) li:last-of-type:has(.previous-point-in-time) > a {
-    padding: 2.05rem 0 0 7.5rem;
+    margin: 0 0 0 calc(var(--maxWidth) - 23.3rem);
     width: 18rem;
+    background: unset;
   }
-  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time) li:last-of-type:has(.previous-point-in-time) > a .version:before {
-    border-top: 0.5em dashed var(--timelineVersionActive);
-    margin: 4rem 50% -4rem -2rem;
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time) li:last-of-type:first-of-type {
+    margin: 0 0 0 calc(var(--maxWidth) - 26.25rem);
   }
-  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time) li:last-of-type:has(.previous-point-in-time) > a .version:after {
-    border-top-color: transparent;
-    margin: 2.2rem 0 0 50%;
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time) li:last-of-type:first-of-type > a .point-in-time {
+    right: 3.1rem;
   }
-  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time) li:last-of-type:has(.previous-point-in-time) > a .point-in-time {
-    left: 0.75rem;
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li:nth-child(3))):has(li:nth-child(2)):has(li:first-of-type .previous-point-in-time):before {
+    width: calc(var(--maxWidth) - 25rem);
+    margin: 6.05rem 0 0 16rem;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li:nth-child(3))):has(li:nth-child(2)):has(li:first-of-type .previous-point-in-time) li:first-of-type > a {
+    padding: 2.05rem 0 0 10rem;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li:nth-child(3))):has(li:nth-child(2)):has(li:first-of-type .previous-point-in-time) li:first-of-type > a .version:before {
+    border-style: solid;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li:nth-child(3))):has(li:nth-child(2)):has(li:first-of-type .previous-point-in-time) li:first-of-type > a .version:after {
+    border-color: transparent;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li:nth-child(3))):has(li:nth-child(2)):has(li:first-of-type .previous-point-in-time) li:first-of-type > a .previous-point-in-time {
     right: unset;
+    left: 4.5rem;
   }
-  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .point-in-time) li:last-of-type:has(.previous-point-in-time) + li .version:before {
-    margin: 4rem 50% -4rem 0;
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .previous-point-in-time):before {
+    width: calc(var(--maxWidth) - 25rem);
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .previous-point-in-time) li:last-of-type {
+    margin: 0 0 0 calc(var(--maxWidth) - 20.875rem);
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:last-of-type .previous-point-in-time) li:last-of-type > a .version:after {
+    border-color: transparent;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type:last-of-type .previous-point-in-time):before {
+    width: calc(var(--maxWidth) - 18rem);
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type:last-of-type .previous-point-in-time) li:last-of-type {
+    margin: 0 0 0 calc(var(--maxWidth) - 20rem);
+    width: 16rem;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type:last-of-type .previous-point-in-time) li:last-of-type:before {
+    display: none;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type:last-of-type .previous-point-in-time) li:last-of-type > a {
+    padding: 2.05rem 0 0 2.5rem;
+    width: 16rem;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type:last-of-type .previous-point-in-time) li:last-of-type > a .version:before {
+    border-color: transparent;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type:last-of-type .previous-point-in-time) li:last-of-type > a .version:after {
+    border-color: transparent;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type:last-of-type .previous-point-in-time) li:last-of-type > a .previous-point-in-time {
+    right: unset;
+    left: 4.5rem;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li:nth-child(3))):has(li:nth-child(2)) {
+    width: 100%;
+    margin: 0;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li:nth-child(3))):has(li:nth-child(2)):before {
+    margin: 6.05rem 0 0 8rem;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li:nth-child(3))):has(li:nth-child(2)) li:first-of-type {
+    position: relative;
+    margin: 0;
+    background: unset;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li:nth-child(3))):has(li:nth-child(2)) li:last-of-type:not(:has(.point-in-time)) {
+    margin: 0 0 0 calc(var(--maxWidth) - 18rem);
+    background: unset;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li:nth-child(3))):has(li:nth-child(2)):has(.prospective) li:first-of-type .version:after {
+    border-color: transparent;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type:last-of-type) {
+    width: 100%;
+    margin: 0;
+    position: relative;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type:last-of-type):before {
+    margin: 6.05rem 0 0 8rem;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type:last-of-type) li {
+    position: unset;
+    margin: 0 0 0 calc(var(--maxWidth) - 18rem);
+    background: unset;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:has(li:first-of-type:last-of-type) li:before {
+    content: "";
+    background: var(--timelineVersionActive);
+    width: 1.65rem;
+    height: 1.65rem;
+    position: absolute;
+    margin: 5.4rem 7.25rem;
+    border-radius: 50%;
+    left: 0;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li[aria-current="page"])) li:not(:last-of-type) > a .version:before,
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li[aria-current="page"])) li:not(:last-of-type) ~ li > a .version:before,
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li[aria-current="page"])) li:not(:last-of-type) ~ :nth-of-type(2):not(:last-of-type) > a .version:before,
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li[aria-current="page"])) li:last-of-type > a .version:before,
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li[aria-current="page"])) li:not(:last-of-type) > a .version:after,
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li[aria-current="page"])) li:not(:last-of-type) ~ li > a .version:after,
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li[aria-current="page"])) li:not(:last-of-type) ~ :nth-of-type(2):not(:last-of-type) > a .version:after,
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li[aria-current="page"])) li:last-of-type > a .version:after {
+    border-color: transparent;
+  }
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li[aria-current="page"])) li:first-of-type:not([aria-current="page"]) ~ :nth-of-type(2) > a .version:before,
+  main.legislation .timeline:has(> details[open]) .versions ol:not(:has(li[aria-current="page"])) li:last-of-type > a .version:before {
+    border-color: var(--timelineVersion);
   }
   main.legislation .timeline:has(> details[open]) .scrollable summary > span:before {
     height: 16rem;
@@ -10898,7 +11064,7 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     border: 0;
   }
   main.legislation .timeline:has(> details[open]) .scrollable .versions .scrollbar button {
-    width: 2.85rem;
+    width: 2.65rem;
     position: relative;
     margin: 0 0.9375rem 0 0.1rem;
     padding: 0;
@@ -10947,7 +11113,7 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   }
   main.legislation .timeline:has(> details[open]) .scrollable .versions .scrollbar .drag-strip {
     position: relative;
-    width: 100%;
+    flex-grow: 1;
     height: 2.5rem;
     padding: 0 0 0.0625rem 0;
   }
@@ -11030,6 +11196,26 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
   }
   main.legislation .timeline:has(> details[open]):has(.scrollable) .versions details:not([open]) summary {
     top: calc(50% - 2.75rem);
+  }
+  main.legislation .timeline:has(> details[open]):has(.scrollable) .versions ol li:first-of-type:before {
+    float: right;
+    content: "";
+    overflow: hidden;
+    display: block;
+    margin: 0 -0.5em 0 0;
+    position: unset;
+    width: 0.4rem;
+    height: 16rem;
+    z-index: unset;
+    background: linear-gradient(270deg, var(--dropShadowStart) 0%, var(--dropShadowEnd) 100%);
+  }
+  main.legislation .timeline:has(> details[open]):has(.scrollable) .scrollable .versions .scrollbar {
+    margin: -4rem 0 0 16rem;
+    width: calc(100% - 32rem);
+  }
+  main.legislation .timeline:has(> details[open]):has(ol li:first-of-type .point-in-time) .scrollable .versions .scrollbar {
+    margin: -4rem 0 0 22rem;
+    width: calc(100% - 38rem);
   }
   main.legislation .timeline:has(> details[open]):has(ol li:last-of-type .point-in-time) .scrollable .versions .scrollbar {
     width: calc(100% - 22rem);
@@ -11272,6 +11458,9 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     transform: rotate(135deg);
     width: 0.65rem;
     height: 0.225em;
+  }
+  main.legislation .legislation-content > aside > div.contributed p {
+    padding: 0.5em 1em;
   }
   main.legislation .legislation-content > aside details {
     margin: 0;
@@ -12168,11 +12357,7 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     background-position: 1.15rem 0.45rem;
     background-size: 1.1rem;
   }
-  main.legislation:has(.timeline details:not([open])) .legislation-content > aside:first-of-type > div.as-enacted-formats {
-    background-position: 1.15rem 0.45rem;
-    background-size: 1.1rem;
-  }
-  main.legislation:has(.timeline details:not([open])) .legislation-content > aside:first-of-type > div.as-enacted-formats.pdf {
+  main.legislation:has(.timeline details:not([open])) .legislation-content > aside:first-of-type > div.as-enacted.pdf {
     background-position: 1.15rem 0.45rem;
     background-size: 1.1rem;
   }
@@ -12204,13 +12389,8 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
     background-position: 0.5rem 0.45rem;
     background-size: 1.1rem;
   }
-  :root .legislation .legislation-content aside > div.as-enacted-formats,
-  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted-formats {
-    background-position: 0.5rem 0.45rem;
-    background-size: 1.1rem;
-  }
-  :root .legislation .legislation-content aside > div.as-enacted-formats.pdf,
-  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted-formats.pdf {
+  :root .legislation .legislation-content aside > div.as-enacted.pdf,
+  :root[colour-scheme="light"] .legislation .legislation-content aside > div.as-enacted.pdf {
     background-position: 0.5rem 0.45rem;
     background-size: 1.1rem;
   }
@@ -12264,4 +12444,145 @@ main aside:not(.legislation aside, .search-filters) ul li article a h3 {
 }
 body:has(.advanced-searches) header .hdr-search {
   display: none;
+}
+.main-menu ul li button {
+  font-weight: 500;
+  color: var(--text);
+  border-radius: 0.1875rem;
+  cursor: pointer;
+  background-color: var(--buttonBg);
+  color: var(--buttonText);
+  border: 0.0625rem solid transparent;
+  padding: 0.5em 1.5em;
+  text-align: center;
+  background-color: transparent;
+  color: var(--buttonBg);
+  border: 0.0625rem solid var(--buttonBg);
+  padding: 0.1rem 0.5em;
+}
+.main-menu ul li button:focus,
+.main-menu ul li button:hover {
+  background-color: var(--focusButtonBg);
+  color: var(--buttonText);
+  border-color: var(--focusOutline);
+  outline-color: var(--focusOutline);
+  outline-style: solid;
+  outline-width: 0.1rem;
+  text-decoration: none;
+  -webkit-box-shadow: 0 0 0.375rem 0 var(--focusShadow);
+  -moz-box-shadow: 0 0 0.375rem 0 var(--focusShadow);
+  box-shadow: 0 0 0.375rem 0 var(--focusShadow);
+}
+.main-menu ul li button:active {
+  background-color: var(--focusButtonBg);
+  color: var(--buttonText);
+  border-color: var(--focusOutline);
+  outline-color: var(--focusOutline);
+  outline-style: solid;
+  outline-width: 0.1rem;
+  text-decoration: none;
+  -webkit-box-shadow: 0 0 0.375rem 0 var(--focusShadow);
+  -moz-box-shadow: 0 0 0.375rem 0 var(--focusShadow);
+  box-shadow: 0 0 0.375rem 0 var(--focusShadow);
+  background-color: var(--modalBg);
+  color: var(--modalText);
+}
+.main-menu ul li button:first-of-type {
+  margin: 0 0.5rem 0 0;
+}
+.main-menu ul li button.selected {
+  background: var(--activeBg);
+  color: var(--activeText);
+  border-color: var(--activeBg);
+}
+:root[timeline-mode="one-original"] {
+  /*
+		@media print and (orientation: portrait), screen and (max-width: calc(1023px - 1px)) {
+			main.legislation .timeline:has(> details[open]) details .versions ol {
+				li {
+					&:first-of-type {border-color: var(--modalTimelinePast)}
+					&:last-of-type {
+						padding: 0;
+						a {padding: 0 0 0 1.25rem}
+					}
+					&.consolidated {
+						&:before {z-index: 1; top: 1.75rem}
+						a {
+							padding: 1.5rem 0 1rem 1.25rem;
+							&:before {content: ""; top: -0.25rem; left: -0.2rem; background: var(--modalTimelinePast); width: 0.2rem}
+							&:after {content: ""; display: block; height: 2rem; width: 1rem; position: absolute; left: -0.6rem; top: -0.75rem; background-image: url(images/timeline-break.png); background-repeat: no-repeat; background-size: 1rem}
+						}
+						.explanation {margin: -0.75rem 0 0.75rem 1.25rem; font-style: italic; font-weight: 300}
+						&:last-of-type {
+							a {padding: 1.5rem 0 0 1.25rem}
+							.explanation {margin: 0.25rem 0 0.75rem 1.25rem}
+						}
+					}
+				}
+			}
+		}
+		
+		@media print and (orientation: landscape), screen and (min-width: 1024px) {
+			main.legislation .timeline {
+				&:has(> details[open]) {
+					> details summary {z-index: 30}
+					.versions ol {
+						margin: 0 16rem; width: calc(100% - 32rem);
+						&:before {width: calc(var(--maxWidth) - 20rem); margin: 6.05rem 0 0 -6rem}
+						&:has(li:last-of-type:nth-of-type(2)) {
+							&:before {display: block}
+						}
+						li {
+							&[aria-current="page"] ~ li:nth-of-type(2) > a .version:before {border-color: var(--timelineVersion)}
+							&:first-of-type {
+								margin: 0 0 0 -16rem; z-index: 20; position: absolute;
+								> a, > div {
+									padding: 2.05rem 0 0 2.4rem; width: 16rem;
+									.date:before {background: var(--bg) var(--timelineVersionIcon); background-size: 40%}
+								}
+								&[aria-current="page"] .date:before {border: 0.2rem solid var(--timelineVersionActive); background: var(--timelineVersionActive) var(--timelineVersionIconActive); background-size: 40%;}
+							}
+							&:not([aria-current="page"]):hover > a .date:before {
+								color: var(--buttonText); border-color: var(--focusOutline); text-decoration: none; -webkit-box-shadow: 0 0 0.375rem 0 var(--focusShadow); -moz-box-shadow: 0 0 0.375rem 0 var(--focusShadow); box-shadow: 0 0 0.375rem 0 var(--focusShadow); outline: 0; background: var(--focusButtonBg) var(--timelineVersionIconHover); background-size: 40%;
+							}
+							&:first-of-type:not([aria-current="page"]) > a .version:after, 
+							&:first-of-type:not([aria-current="page"]) > div .version:after,
+							&:first-of-type:not([aria-current="page"]) ~ :nth-of-type(2) > a .version:before,
+							&:first-of-type:not([aria-current="page"]) ~ :nth-of-type(2) > div .version:before
+							{
+								border-color: var(--timelineVersionActive)
+							}
+							&:last-of-type {margin: 0 0 0 calc(var(--maxWidth) - 34rem)}
+							&.consolidated {
+								> a, > div {
+									padding: 2.05rem 0 0 2.5rem;
+									.version:before {margin: 4rem 50% -4rem -2.5rem}
+								}					
+								a:before {left: 1rem}
+								.explanation {.sr-only}
+							}
+						}
+						&:not(:has(li:nth-child(4))):has(li:nth-child(3)) {
+							margin: 0 16rem 0 0; width: calc(100% - 16rem);
+							&:before {margin: 6.05rem 0 0 8rem}
+							li:first-of-type {position: relative; margin: 0; background: unset}
+							li:last-of-type {margin: 0 0 0 calc(var(--maxWidth) - 18rem)}
+							&:has(.prospective) li:first-of-type .version:after {border-color: transparent}
+						}
+						&:has(li:nth-of-type(2):last-of-type) {
+        					width: calc(100% - 16rem);
+							li:last-of-type {position: relative; background: unset}
+							&:has(li:first-of-type.current) {
+								li:first-of-type a:before {content: ""; display: block; width: 1.65rem; height: 1.65rem; margin: 3.45rem auto 1.75rem auto; border-radius: 50%; background: var(--timelineVersionActive)}
+							}
+						}
+					}
+				}
+				&:has(.scrollable):has(> details[open]) {
+					.versions ol li:first-of-type:before {float: right; content: ""; overflow: hidden; display: block; margin:  0 -0.5em 0 0; position: unset; width: 0.4rem; height: 16rem; z-index: unset; background: linear-gradient(270deg, var(--dropShadowStart) 0%, var(--dropShadowEnd) 100%)}
+					.scrollable .versions .scrollbar {margin: -4rem 0 0 16rem; width: calc(100% - 32rem)}
+				}
+			}
+		}
+	*/
 }

--- a/lgu2/static/new_theme/default_v4.js
+++ b/lgu2/static/new_theme/default_v4.js
@@ -7,6 +7,20 @@
 	var animateInterval = 0
 
 	$(document).ready(function() {
+	// dev environment only - to compare 'one-original' and 'two-originals' timelines
+		$('.main-menu button').on('click', function() {
+			var theButtonId = $(this).attr('id')
+			toggleTimelineMode(theButtonId)
+		})
+		if(localStorage.getItem('timeline-mode')) {
+			var mode = localStorage.getItem('timeline-mode')
+		}
+		else {
+			mode = 'two-originals'
+		}
+		toggleTimelineMode(mode)
+	// End dev environment only
+
     // For demo purposes only - show/hide design approaches
         var urlParams = new URLSearchParams(window.location.search);
         if(urlParams.has('approach')) {
@@ -33,7 +47,7 @@
         else if($('.current-design').length != 0) {
             $('.proposed-design').remove();
         }
-    // Eend demo
+    // End demo
 
 	// To undo hiding of browse dataset unavailable to user agents that do not have JS enabled
 		$('.scrollbar.initialise').removeAttr('hidden')
@@ -53,6 +67,13 @@
 	// If a Table of Contents
 		if($('.legislation .toc-detail').length != 0) {
 			$('.toc-detail li .extent').each(function() {
+				$(this).addClass('hidden')
+			})
+		}
+
+	// If legislation extent
+		if($('.legislation').length != 0) {
+			$('.legislation-text .extent').each(function() {
 				$(this).addClass('hidden')
 			})
 		}
@@ -281,17 +302,26 @@
 	// If on the advanced search page
         if($('.advanced-searches').length != 0) {
             $('.search-type input#primary').change(function() {
-                if($('.search-type input#primary').is(':checked')) {                    
+                if($('.search-type input#primary').is(':checked')) {
+                    $('#primary-types input').prop('checked', true);
+                }
+                else {
                     $('#primary-types input').prop('checked', false);
                 }
             })
             $('.search-type input#secondary').change(function() {
                 if($('.search-type input#secondary').is(':checked')) {
+                    $('#secondary-types input').prop('checked', true);
+                }
+                else {
                     $('#secondary-types input').prop('checked', false);
                 }
             })
             $('.search-type input#eu').change(function() {
                 if($('.search-type input#eu').is(':checked')) {
+                    $('#eu-types input').prop('checked', true);
+                }
+                else {
                     $('#eu-types input').prop('checked', false);
                 }
             })
@@ -346,7 +376,7 @@
 			});
 
 		// Scroll to the selected year
-			setTimeout(function() { 
+			//setTimeout(function() { 
 				loadVersion('all','noanim')
 				var theYear = getUrlVars()["year"];
 				if(theYear !== 'undefined' && theYear !== '' && theYear !== false) {
@@ -369,7 +399,7 @@
 						}
 					})
 				}
-			},20)
+			//},20)
 
 		// Selecting a year from the dataset
 			$('.dataset > div:first-of-type dt a').on('click', function() {
@@ -434,22 +464,26 @@
 			}
 
 		// If timeline is open on page load, set scrollbar
-			if($('.timeline details').is('[open]'))
+			if($('.timeline > details').is('[open]'))
 			{
-				setTimeout(function(){
+			//	setTimeout(function(){
 					openTimeline()
-				},1)
+				//},1)
 			}
 
 		// Timeline controls
-			$('.timeline summary').on('click', function() {
+			$('.timeline > details > summary').on('click', function() {
 				if ($(window).width() > 1023) {
 					openTimeline()
-					if($('.timeline details').is('[open]'))
+					if($('.timeline > details').is('[open]'))
 					{
-						setTimeout(function(){
-							$('.timeline details').removeClass('scrollable')
-						},1)
+						//setTimeout(function(){
+							$('.timeline > details').removeClass('scrollable')
+						//},1)
+						localStorage.setItem('timeline', 'closed')
+					}
+					else {
+						localStorage.removeItem('timeline')
 					}
 				}
 			})
@@ -461,13 +495,11 @@
 				loadVersion(this)
 			})
 
-		// Open timeline if historical version is selected 
-			if($(window).width() > 1023 && (!$('li:last-of-type').is('[aria-current]')))
+		// Open timeline 
+			if($(window).width() > 1023 && !(localStorage.getItem('timeline')) /* && (!$('li:last-of-type:not(:has(.point-in-time))').is('[aria-current]') || $('li:last-of-type').is('.prospective'))*/)
 			{
-				setTimeout(function() { 
-					$('.timeline details').prop('open',true)
-					openTimeline()
-				},150)
+				openTimeline()
+				$('.timeline > details:not(:has(summary[disabled])').prop('open',true)
 			}
 		}
 		
@@ -478,9 +510,15 @@
 			$('.timeline ol').scroll(function() {
 				var scrollbarwidth = $('.scrollbar').width()
 				var liwidth = $('.timeline ol').children('li:not(:first-of-type, :last-of-type, :has(.point-in-time)):first').width()
-				var liOriginalWidth = $('.timeline ol').children('li:first-of-type').width()
-				var liOriginalMargin = Number($('.timeline ol').children('li:first-of-type').css("margin-right").replace("px", ""))
+				var liOriginalWidth = 0
+				var liOriginalMargin = 0
 				var noOfPiTs = ($('.timeline ol').children('li:not(:first-of-type, :last-of-type):has(.point-in-time)').length)
+			// dev environment only - to compare 'one-original' and 'two-originals' timelines
+				if(localStorage.getItem('timeline-mode') == 'two-originals') {
+					liOriginalWidth = $('.timeline ol').children('li:first-of-type').width()
+					liOriginalMargin = Number($('.timeline ol').children('li:first-of-type').css("margin-right").replace("px", ""))
+				}
+			// End dev environment only
 				var addForPiT = $('.timeline ol').children('li:not(:first-of-type, :last-of-type):has(.point-in-time)').outerWidth() - liwidth
 				var olwidth = liOriginalWidth + liOriginalMargin + ($('.timeline ol').children('li').length - 2) * liwidth - scrollbarwidth + (addForPiT * noOfPiTs)
 				var scrollx = $('.timeline ol').scrollLeft()
@@ -605,9 +643,15 @@
 				if($('.timeline').length != 0) 
 				{
 					liwidth = $('.timeline ol').children('li:not(:first-of-type, :last-of-type, :has(.point-in-time)):first').width()
-					liOriginalWidth = $('.timeline ol').children('li:first-of-type').width()
-					liOriginalMargin = Number($('.timeline ol').children('li:first-of-type').css("margin-right").replace("px", ""))
+					liOriginalWidth = 0
+					liOriginalMargin = 0
 					noOfPiTs = ($('.timeline ol').children('li:not(:first-of-type, :last-of-type):has(.point-in-time)').length)
+				// dev environment only - to compare 'one-original' and 'two-originals' timelines
+					if(localStorage.getItem('timeline-mode') == 'two-originals') {
+						liOriginalWidth = $('.timeline ol').children('li:first-of-type').width()
+						liOriginalMargin = Number($('.timeline ol').children('li:first-of-type').css("margin-right").replace("px", ""))
+					}
+				// End dev environment only
 					addForPiT = $('.timeline ol').children('li:not(:first-of-type, :last-of-type):has(.point-in-time)').outerWidth() - liwidth
 					olwidth = liOriginalWidth + liOriginalMargin + ($('.timeline ol').children('li').length - 2) * liwidth - scrollbarwidth + (addForPiT * noOfPiTs)
 				}
@@ -636,14 +680,21 @@
 			})
 	}
 
-	// If a Table of Contents
-		if($('.legislation .toc-detail').length != 0) {
+	// Extent buttons
+		if($('.toc-detail').length != 0) {
 			$('#toc').on('click', function() {
 				expandToc($(this))
 			})
 			$('.legislation-content aside .extent button').on('click', function() {
 				tocExtent($(this))
 			})
+		}
+		else if($('.legislation-text').length != 0) {
+            if($('.extent').length != 0) {
+                $('.legislation-content aside .extent button').on('click', function() {
+                    legExtent($(this))
+                })
+            }
 		}
 		
 	// If there is legislation text
@@ -717,8 +768,10 @@
 			if(localStorage.getItem('statusPanel')) {
 				var pinStatus = localStorage.getItem('statusPanel')
 				if(pinStatus == 'pinned') {
-					$('.status-panel').addClass('pinned')
-					$('.status-panel button span').text('Unpin this panel')
+					$('.status-panel.not-up-to-date').addClass('pinned')
+					$('.status-panel.not-up-to-date button span').text('Unpin this panel')
+					$('.status-panel.up-to-date').addClass('pinned')
+					$('.status-panel.up-to-date button span').text('Unpin this panel')
 				}
 			}
 			$('.status-panel summary').on('click', function() {
@@ -730,7 +783,7 @@
 				}
 			})
 			
-			$('.legislation-content > aside > div.not-up-to-date button').on('click', function() {
+			$('.legislation-content > aside > div.up-to-date button').on('click', function() {
 				if($('.status-panel details').is('[open]')) {
 					$('.status-panel details').removeAttr('open')
 					hideStatusPanel()
@@ -750,9 +803,9 @@
 				{
 					$('.hdr-menu details').removeAttr('open')
 				}
-				if($(window).width() < 1023 && $('.timeline details').is('[open]'))
+				if($(window).width() < 1023 && $('.timeline > details').is('[open]'))
 				{
-					$('.timeline details').removeAttr('open')
+					$('.timeline > details').removeAttr('open')
 				}
 				else if($(window).width() < 1023 && $('.hdr-search details').is('[open]'))
 				{
@@ -839,6 +892,22 @@
 				if($(window).scrollTop() < $('main article h2:first-of-type:not(nav h2)').offset().top) {
 					setDynamicLeftHandNav()
 				}
+			}
+
+		// Open/close timeline 
+			if($(window).width() > 1023 && !(localStorage.getItem('timeline')))
+			{
+				//setTimeout(function() { 
+					$('.timeline > details:not(:has(summary[disabled])').prop('open',true)
+					openTimeline()
+				//},150)
+			}
+			else
+			{
+				//setTimeout(function() { 
+					$('.timeline > details:not(:has(summary[disabled])').removeAttr('open')
+					openTimeline()
+				//},150)
 			}
 		})
 	})
@@ -1089,7 +1158,7 @@
 				var olScrollwidth = $('.timeline ol').get(0).scrollWidth
 				if(olScrollwidth > olWidth)
 				{
-					$('.timeline details').addClass('scrollable')
+					$('.timeline > details').addClass('scrollable')
 				}
 			}
 			$('.versions li').each(function() {
@@ -1098,7 +1167,7 @@
 					loadVersion($(this).children('a'),'noanim')
 				}
 			})
-		},1)
+		},25)
 	}
 
 	function loadVersion(version,anim) {
@@ -1126,16 +1195,21 @@
 			scrollbarwidth = $('.scrollbar').width()
 			index = $(version).index()
 			var liwidth = $('.timeline ol').children('li:not(:first-of-type, :last-of-type, :has(.point-in-time)):first').width()
-			var noOfPiTs = ($('.timeline ol').children('li:not(:first-of-type, :last-of-type):has(.point-in-time)').length)
+			var noOfPiTs = ($('.timeline ol').children('li:not(:last-of-type):has(.point-in-time)').length) + 1
+		// dev environment only - to compare 'one-original' and 'two-originals' timelines
+			if(localStorage.getItem('timeline-mode') == 'two-originals') {
+				noOfPiTs = ($('.timeline ol').children('li:not(:first-of-type, :last-of-type):has(.point-in-time)').length)
+			}
+		// End dev environment only
 			var addForPiT = $('.timeline ol').children('li:not(:first-of-type, :last-of-type):has(.point-in-time)').outerWidth() - liwidth
 			
-			setTimeout(function(){
+			//setTimeout(function(){
 				$('.timeline ol').animate({scrollLeft: ((index * liwidth) + (addForPiT * noOfPiTs) + (liwidth / 2) - (scrollbarwidth * 0.5))}, animateInterval)
-			},1)
+			//},20)
 			
 			if($(window).width() < 1023)
 			{
-				$('.timeline details').removeAttr('open')
+				$('.timeline > details').removeAttr('open')
 			}
 		}
 		else if($('.dataset').length != 0) 
@@ -1214,6 +1288,23 @@
 		}
 	}
 
+	function legExtent(element) {
+		if($('.extent button.expanded').length != 0) {
+			$(element).removeClass('expanded')
+			$(element).text('Show geographical extent')
+			$('.extent').each(function() {
+				$(this).addClass('hidden')
+			})
+		}
+		else {
+			$(element).addClass('expanded')
+			$(element).text('Hide geographical extent')
+			$('.extent').each(function() {
+				$(this).removeClass('hidden')
+			})
+		}
+	}
+
 	function pinStatusPanel() {
 		if($('.status-panel.pinned').length != 0) {
 			$('.status-panel').removeClass('pinned')
@@ -1222,22 +1313,91 @@
 			localStorage.removeItem('statusPanel')
 		}
 		else {
-			$('.status-panel').addClass('pinned')
-			$('.status-panel button span').text('Unpin this panel')
+			$('.status-panel.not-up-to-date').addClass('pinned')
+			$('.status-panel.not-up-to-date button span').text('Unpin this panel')
+			$('.status-panel.up-to-date').addClass('pinned')
+			$('.status-panel.up-to-date button span').text('Unpin this panel')
 			localStorage.setItem('statusPanel', 'pinned')
 		}
 	}
 
 	function showStatusPanel() {
-		var collapseLabel = $('.status-panel summary').data('collapse-label') || 'Hide detail of these changes'
-		$('.legislation-content > aside > div.not-up-to-date button').text(collapseLabel)
-		$('.legislation-content > aside > div.not-up-to-date button').attr('aria-expanded',true)
-		$('.status-panel summary').text(collapseLabel)
+		$('.legislation-content > aside > div.up-to-date button').text('Hide detail of these changes')
+		$('.legislation-content > aside > div.up-to-date button').attr('aria-expanded',true)
+		$('.status-panel summary').text('Hide the detail of these changes')
 	}
 
 	function hideStatusPanel() {
-		var expandLabel = $('.status-panel summary').data('expand-label') || 'See what these changes are'
-		$('.status-panel summary').text(expandLabel)
-		$('.legislation-content > aside > div.not-up-to-date button').text(expandLabel)
-		$('.legislation-content > aside > div.not-up-to-date button').attr('aria-expanded',false)
+		$('.status-panel summary').text('See the outstanding changes')
+		$('.legislation-content > aside > div.up-to-date button').text('See outstanding changes')
+		$('.legislation-content > aside > div.up-to-date button').attr('aria-expanded',false)
 	}
+
+// dev environment only - to compare 'one-original' and 'two-originals' timelines
+	function toggleTimelineMode(mode) {
+		/*$('.main-menu button').removeClass('selected')
+		if(mode == 'two-originals' || mode == '') {
+			localStorage.removeItem('timeline-mode')
+			$('#two-originals').addClass('selected')
+			document.documentElement.setAttribute('timeline-mode', 'two-originals')
+		}
+		else {
+			localStorage.setItem('timeline-mode', mode)
+			$('#one-original').addClass('selected')
+			document.documentElement.setAttribute('timeline-mode', 'one-original')
+		}
+
+		if($('.timeline').length != 0) {
+				var firstDate = $('.timeline ol li:first-of-type .date span').contents().first().text();
+				var secondDate = $('.timeline ol li:nth-of-type(2) .date span').contents().first().text();
+			if(localStorage.getItem('timeline-mode') == 'one-original') {
+				$('.timeline ol li:first-of-type .version .title').text('The original version');
+				if(firstDate == secondDate) {
+					$('.timeline ol li:nth-of-type(2):not(:last-of-type)').css('display','none')
+					$('.timeline ol:has(li:nth-of-type(2):last-of-type) li:first-of-type').addClass('current')
+					$('.timeline ol:has(li:nth-of-type(2):last-of-type) li:first-of-type a').children().css('display','none')
+					if($('.timeline ol li:first-of-type.current').is('[aria-current]')) {
+						$('.timeline ol li:first-of-type.current').addClass('revertToSelected')
+						$('.timeline ol li:first-of-type.current').removeAttr('aria-current','page')
+						$('.timeline ol li:last-of-type').attr('aria-current','page')
+						$('.timeline ol li:last-of-type').find('.version').prepend($('<span class="prefix">You are viewing </span>'))
+					}
+					if($('.timeline ol li:nth-of-type(2):not(:last-of-type)').is('[aria-current]')) {
+						$('.timeline ol li:nth-of-type(2)').addClass('revertToSelected')
+						$('.timeline ol li:first-of-type').attr('aria-current','page')
+						$('.timeline ol li:nth-of-type(2)').removeAttr('aria-current','page')
+						$('.timeline ol li:first-of-type').find('.version').prepend($('<span class="prefix">You are viewing </span>'))
+					}
+				}
+				else {
+					$('.timeline ol li:nth-of-type(2):not(:last-of-type) .version .title').text('A historical version');
+				}
+			}
+			/*else {
+				$('.timeline ol li:first-of-type .version .title').text('The original text');
+				$('.timeline ol li:nth-of-type(2)').css('display','')
+				if(firstDate == secondDate) {
+					$('.timeline ol:has(li:nth-of-type(2):last-of-type) li:first-of-type').removeClass('current')
+					$('.timeline ol:has(li:nth-of-type(2):last-of-type) li:first-of-type a').children().css('display','')
+					if($('.timeline ol li:first-of-type.revertToSelected').length != 0) {
+						$('.timeline ol li:first-of-type.revertToSelected').removeClass('revertToSelected')
+						$('.timeline ol li:first-of-type').attr('aria-current','page')
+						$('.timeline ol li:last-of-type').removeAttr('aria-current','page')
+						$('.timeline ol li:first-of-type').find('.version').prepend($('<span class="prefix">You are viewing </span>'))
+						$('.timeline ol li:last-of-type a .prefix').remove()
+					}
+					if($('.timeline ol li:nth-of-type(2).revertToSelected').length != 0) {
+						$('.timeline ol li:nth-of-type(2)').removeClass('revertToSelected')
+						$('.timeline ol li:nth-of-type(2)').attr('aria-current','page')
+						$('.timeline ol li:first-of-type').removeAttr('aria-current','page')
+						$('.timeline ol li:nth-of-type(2)').find('.version').prepend($('<span class="prefix">You are viewing </span>'))
+						$('.timeline ol li:first-of-type a .prefix').remove()
+					}
+				}
+				else {
+					$('.timeline ol li:nth-of-type(2):not(:last-of-type) .version .title').text('Our 1st annotated version');
+				}
+			}
+		}*/
+	}
+// End dev environment only

--- a/lgu2/static/new_theme/default_v4.less
+++ b/lgu2/static/new_theme/default_v4.less
@@ -188,8 +188,8 @@ body:not(:-moz-handler-blocked) fieldset {
 						}
 						&.repealed {background: url('images/repealed.png') no-repeat 0.25em 0.375em; background-size: 1.35em}
 						&.dated-version {background: url('images/dated-version.png') no-repeat 0.25em 0.575em; background-size: 1.25em}
-						&.as-enacted-formats {background: url('images/timeline-version.png') no-repeat 0.35em 0.65em; background-size: 1em}
-						&.as-enacted-formats.pdf {background: url('images/kpv-pdf.png') no-repeat 0.05em 0.575em; background-size: 1.5em}
+                        &.as-enacted {background: url('images/as-enacted.png') no-repeat 0.25em 0.575em; background-size: 1.25em}
+						&.as-enacted.pdf {background: url('images/kpv-pdf.png') no-repeat 0.05em 0.575em; background-size: 1.5em}
 						&.extent {background: url('images/extent.png') no-repeat 0.125em 0.625em; background-size: 1.5em}
 						&.in-force {
 							background: url('images/in-force.png') no-repeat 0.125em 0.575em; background-size: 1.5em;
@@ -199,7 +199,6 @@ body:not(:-moz-handler-blocked) fieldset {
 						&.blanket-amendments {background: url('images/blanket-amendments.png') no-repeat 0.15em 0.5em; background-size: 1.45em}
 						&.explanatory-notes {background: url('images/explanatory-notes.png') no-repeat 0.25em 0.6em; background-size: 1.3em}
 						&.associated-documents {background: url('images/associated-documents.png') no-repeat 0.15em 0.5em; background-size: 1.45em}
-                        &.as-enacted {background: url('images/as-enacted.png') no-repeat 0.25em 0.575em; background-size: 1.25em}
 					}
 					details {
 						&.other-formats {
@@ -417,8 +416,8 @@ body:not(:-moz-handler-blocked) fieldset {
 						}
 						&.repealed {background: url('images/repealed-dm.png') no-repeat 0.25em 0.375em; background-size: 1.35em}
 						&.dated-version {background: url('images/dated-version-dm.png') no-repeat 0.25em 0.575em; background-size: 1.25em}
-						&.as-enacted-formats {background: url('images/timeline-version-active.png') no-repeat 0.35em 0.65em; background-size: 1em}
-						&.as-enacted-formats.pdf {background: url('images/kpv-pdf-dm.png') no-repeat 0.05em 0.575em; background-size: 1.5em}
+                        &.as-enacted {background: url('images/as-enacted-dm.png') no-repeat 0.25em 0.575em; background-size: 1.25em}
+						&.as-enacted.pdf {background: url('images/kpv-pdf-dm.png') no-repeat 0.05em 0.575em; background-size: 1.5em}
 						&.extent {background: url('images/extent-dm.png') no-repeat 0 0.625em; background-size: 1.5em}
 						&.in-force {
 							background: url('images/in-force-dm.png') no-repeat 0.125em 0.575em; background-size: 1.5em;
@@ -428,7 +427,6 @@ body:not(:-moz-handler-blocked) fieldset {
 						&.blanket-amendments {background: url('images/blanket-amendments-dm.png') no-repeat 0.15em 0.5em; background-size: 1.45em}
 						&.explanatory-notes {background: url('images/explanatory-notes-dm.png') no-repeat 0.125em 0.6em; background-size: 1.3em}
 						&.associated-documents {background: url('images/associated-documents-dm.png') no-repeat 0.15em 0.5em; background-size: 1.45em}
-                        &.as-enacted {background: url('images/as-enacted-dm.png') no-repeat 0.25em 0.575em; background-size: 1.25em}
 					}
 				}
 				> div .legislation-ftr aside h3 {
@@ -634,7 +632,7 @@ body:not(:-moz-handler-blocked) fieldset {
 		&:before {content: ''; position: absolute; width: calc(100% - 1.875rem); height: 0.25rem; background: var(--timelineVersionActive); display: block; margin: 1.15rem 0.9375rem} 
 		h3 {.sr-only()}
 		button {
-			width: 2.85rem; position: relative; margin: 0 0.9375rem 0 0.1rem; padding: 0; height: 2.5rem;
+			width: 2.65rem; position: relative; margin: 0 0.9375rem 0 0.1rem; padding: 0; height: 2.5rem;
 			&:after {.chevron(); margin: 0.15rem 0; width: 0.35rem; height: 0.35rem; border-color: var(--buttonText)}
 			&:first-of-type {
 				margin: 0 0.1rem 0 0.9375rem;
@@ -644,7 +642,7 @@ body:not(:-moz-handler-blocked) fieldset {
 			span {.sr-only()}
 		}
 		.drag-strip {
-			position: relative; width: 100%; height: 2.5rem; padding: 0 0 0.0625rem 0;
+			position: relative; flex-grow: 1; height: 2.5rem; padding: 0 0 0.0625rem 0;
 			.drag {
 				margin: 0 0 -0.0625rem 0; width: 5rem; height: 2.5rem; background: var(--buttonBg); border-radius: 0.15em; position: absolute !important;
 				&:before {.chevron(); position: absolute; left: 1rem; margin: 1rem 0; width: 0.35rem; height: 0.35rem; border: 0; border-bottom: 0.0625rem solid var(--buttonText); border-left: 0.0625rem solid var(--buttonText)}
@@ -1832,37 +1830,47 @@ body:not(:-moz-handler-blocked) fieldset {
                             //.point-in-time:before {background: var(--alert); z-index: 1}
 						}
 					}
+					&:has(.versions li[aria-current="page"] .previous-point-in-time) {
+						summary {
+							.version {
+								&:before {border-top-color: transparent}
+								&:after {border-top: 0.5em dashed var(--timelineVersionActive)}					
+							}
+                            //.point-in-time:before {background: var(--alert); z-index: 1}
+						}
+					}
+					&:has(.versions li:last-of-type[aria-current="page"] .previous-point-in-time) {
+						summary {
+							.version {
+								&:before {border-top-color: var(--timelineVersionActive)}
+								&:after {border-top: 0.5em dashed var(--timelineVersionActive)}					
+							}
+                            //.point-in-time:before {background: var(--alert); z-index: 1}
+						}
+					}
 					summary .date {display: none}
 				}
 									
 				&:has(.versions li:first-of-type[aria-current="page"]) {
-					summary {
-						 .version {
-							&:before, &:after {border-top-color: transparent}
-						}
-						.date:before {background: var(--timelineVersionActive) var(--timelineEnactedVersionIconActive); background-size: 55%}
-					}
-				}
-				&:has(.versions li:nth-of-type(2)[aria-current="page"]) {
 					summary .version {
-						&:before, &:after {border-top-color: transparent}
+						&:before {border-top-color: transparent}
+						&:after {border-top-color: var(--timelineVersion)}
 					}
-					&:has(.versions li:nth-of-type(3)) {
+					&:has(.versions li:last-of-type[aria-current="page"]) {
 						 summary .version {
-							&:before {border-top-color: transparent}
-							&:after {border-top-color: var(--timelineVersion)}
+							&:after {border-top-color: transparent}
 						}
 					}
-					&:has(.versions li[aria-current="page"] .point-in-time:not(.previous-point-in-time)) {
+					&:has(.versions .previous-point-in-time) {
 						 summary .version {
-							&:before {border-top-color: var(--timelineVersionActive)}
+						&:before {border-top-color: var(--transparent)}
+						&:after {border-top-color: var(--timelineVersionActive)}
 						}
 					}
 				}
 
-				&:has(.versions li:last-of-type[aria-current="page"]:nth-of-type(n+3)) {
+				&:has(.versions li:last-of-type[aria-current="page"]) {
 					summary .version {
-						&:before {border-top-color: var(--timelineVersionActive)}
 						&:after {border-top-color: transparent}
 					}
 				}
@@ -1928,7 +1936,7 @@ body:not(:-moz-handler-blocked) fieldset {
 						> a:first-of-type {padding: 0.4em 0 0 2em}
 					}
 					&.up-to-date ul {.toggle; margin: 0.35rem 1em 0.5em 2em}
-                    &.as-enacted-formats {
+                    &.as-enacted {
                         p {height: 2.25rem; padding: 0.15rem 0 0.15rem 2rem; display: table-cell; display: table-cell; vertical-align: middle}    
                     }
 				}
@@ -2019,11 +2027,13 @@ body:not(:-moz-handler-blocked) fieldset {
 								}
 							}
 							li {margin: 0.25em 0 0 0}
+							&:has(h3) > .prefix {font-weight: 500; line-height: 1.5rem}
 						}
 					}
 					.prefix {
 						position: absolute; margin: 0 0 0 -8em; width: 7.5em; text-align: right;
 						.wrapper {display: inline-block; line-height: 1.2em}
+						.marker .annotation {line-height: 1.5em}
 					}
                     iframe {width: 100%; height: 90vH}
 							.extent {
@@ -2235,9 +2245,12 @@ body:not(:-moz-handler-blocked) fieldset {
 							summary:after {border-top-width: 0.15rem; border-right: 0; border-bottom: 0; border-left-width: 0.15rem; margin: 0.185em 0.35em 0 0.5em}
 							&::details-content {}
 							> div {
-								max-height: 25vh; overflow-y: scroll; padding: 0 1rem; scroll-timeline: --scroll;
+								max-height: 25vh; overflow-y: scroll; padding: 0; scroll-timeline: --scroll;
+								h3 {font-size: 1.05rem; margin: 0 0 0.25rem 0; padding: 0.65rem 1rem; background: var(--altBg)}
+								h4 {font-size: 1rem; padding: 0.25rem 1rem 0.15rem 1rem}
 								ul {
-									padding: 0.75rem 0; margin: 0; list-style: none;
+									padding: 0.35rem 1rem 0.75rem 1rem; margin: 0; list-style: none;
+									&:first-child {padding: 0.75rem 0}
 									* {font-family: "Roboto"}
 									li {
 										margin: 0 0 0.25rem 0; font-weight: 300;
@@ -2274,9 +2287,11 @@ body:not(:-moz-handler-blocked) fieldset {
 		}
 
         &:has(.previous-point-in-time, .not-commenced) {
+		/*
             .legislation-content > aside > div.in-force {
 				border-top: 0.125rem dashed var(--subtleBorder);
 			}
+		*/
 			.legislation-content > div {
 				.legislation-text {
                      &:has(> p) {
@@ -2494,22 +2509,21 @@ body:not(:-moz-handler-blocked) fieldset {
 								&:first-of-type {padding: 0.35em 0 0.15rem 2em; border-top: 0.0625rem solid var(--subtleBorder)}
 							}
 							&.not-up-to-date p:first-of-type {background-position: 0.05rem 0.3rem}
-                            &.as-enacted-formats, &.as-enacted-formats.pdf {
-                                background-position: 1.25em 0.55em; flex-grow: unset;
+                            &.as-enacted.pdf {
+                                background-position: 0.75em 0.55em; flex-grow: unset;
                                 p {min-height: 2.25rem; padding: 0.5rem 0 0.15rem 2rem}
-                            }
-                            &.as-enacted-formats.pdf {
-                                background-position: 0.75em 0.55em;
                             }
 						}
 					}
 				}
-                &:has(.previous-point-in-time, .not-commenced) {
+			/*
+				&:has(.previous-point-in-time, .not-commenced) {
 					.legislation-content > aside > div.in-force {
 						p:first-of-type {border-top: 0.125rem dashed var(--subtleBorder)}
 						+ .in-force p:first-of-type {border-color: var(--alert); padding: 0.55em 0 0.55rem 2em}
 					}
                 }
+			*/
                 &:has(.prospective[aria-current="page"]) {
                     .legislation-content > aside > div.in-force p:first-of-type {border-top: 0.125rem dashed var(--subtleBorder)}
                 }
@@ -2615,19 +2629,29 @@ body:not(:-moz-handler-blocked) fieldset {
 											color: var(--disabledModalText);
 											&:before {border: 0.2rem solid var(--disabledButtonBorder)}
 										}
-                                        &.consolidated {
-                                            &:before {top: 1.5rem}
-                                            a {
-                                                padding: 1.5rem 0 1rem 2rem;
-                                                &:before {content: ""; display: block; height: 2rem; width: 1rem; position: absolute; left: 0.25rem; top: -1.0rem; background-image: url('images/timeline-break.png'); background-repeat: no-repeat; background-size: 1rem}
-                                            }
-                                        }
                                         &:has(~ [aria-current="page"]) {
                                             &:not(:first-of-type, :last-of-type):after {background: var(--bg)}
                                             &:before {background: var(--modalTimelinePast)}
 											&:first-of-type:has(> div):before {background: transparent}
                                         }
-										&:first-of-type, &:last-of-type {border-color: transparent}
+										&:last-of-type {
+											padding: 0; border-color: transparent;
+											a {padding: 0 0 0 1.25rem}
+										}
+										
+										&.consolidated {
+											&:before {z-index: 1; top: 1.75rem}
+											a {
+												padding: 1.5rem 0 1rem 1.25rem;
+												&:before {content: ""; top: -0.25rem; left: -0.2rem; height: 2rem; position: absolute; background: var(--modalTimelinePast); width: 0.2rem}
+												&:after {content: ""; display: block; height: 2rem; width: 1rem; position: absolute; left: -0.6rem; top: -0.75rem; background-image: url(images/timeline-break.png); background-repeat: no-repeat; background-size: 1rem}
+											}
+											.explanation {margin: -0.75rem 0 0.75rem 1.25rem; font-style: italic; font-weight: 300}
+											&:last-of-type {
+												a {padding: 1.5rem 0 0 1.25rem}
+												.explanation {margin: 0.25rem 0 0.75rem 1.25rem}
+											}
+										}				
 									}
 								}
 								a {color: var(--modalText)}
@@ -2659,7 +2683,7 @@ body:not(:-moz-handler-blocked) fieldset {
 					> aside {
 						border: 0.0625rem solid var(--subtleBorder); border-radius: 0.35rem; padding: 0.5rem 0.75rem 0.25rem 0.75rem; background: var(--verySubtleBg);
 						&:has(.not-up-to-date) {border: 0.13rem dashed var(--warningBorder)}
-						> div.as-enacted-formats {
+						> div.as-enacted {
 							display: table; width: -webkit-fill-available;
                                 p {padding: 0.25rem 0 0.25rem 2rem}
 							}
@@ -3356,16 +3380,12 @@ body:not(:-moz-handler-blocked) fieldset {
                             &.up-to-date, &.up-to-date + .up-to-date {background-position: 0.75em 0.65em; background-size: 1.5em}
                             &.repealed {background-position: 0.7em 0.6em; background-size: 1.75em}
                             &.dated-version {background-position: 0.7em 0.6em; background-size: 1.6em}
-                            &.as-enacted-formats {
-                                background-position: 0.85em 0.65em; background-size: 1.1em;
-                                p {padding: 0.5em 0.5em 0.35em 3em}
-								&:not(.pdf) {
-									a {font-weight: 500}
-								}
-                            }
-                            &.as-enacted-formats.pdf {
-								background-position: 0.45em 0.6em; background-size: 1.8em;
+                            &.as-enacted {background-position: 0.8em 0.65em; background-size: 1.4em;
 								&:has(a) {border-color: var(--link)}
+							}
+                            &.as-enacted.pdf {
+								background-position: 0.45em 0.6em; background-size: 1.8em;
+                                p {padding: 0.5em 0.5em 0.35em 3em}
 							}
                             &.extent {
                                 background-position: 0.5em 0.6em; background-size: 2em;
@@ -3376,9 +3396,6 @@ body:not(:-moz-handler-blocked) fieldset {
                             &.blanket-amendments {background-position: 0.45em 0.675em; background-size: 2em}
                             &.explanatory-notes {background-position: 0.6em 0.5em; background-size: 1.6em; border-color: var(--link)}
                             &.associated-documents {background-position: 0.65em 0.5em; background-size: 1.5em}
-                            &.as-enacted {background-position: 0.8em 0.65em; background-size: 1.4em;
-								&:has(a) {border-color: var(--link)}
-							}
                             &:has(p) {
                                 &.explanatory-notes {background-position: 0.65em 0.6em; background-size: 1.6em; border-color: var(--lessSubtleBorder)}
                                 &.associated-documents {background-position: 0.55em 0.6em; background-size: 1.8em}
@@ -3386,11 +3403,13 @@ body:not(:-moz-handler-blocked) fieldset {
                         }
                     }
                 }
+			/*
                 &:has(.previous-point-in-time, .not-commenced) {
                     .legislation-content > aside > div.in-force {
 						border: 0.125rem dashed var(--lessSubtleBorder);
 					}
                 }
+			*/
                 &:has(.prospective[aria-current="page"]) {
                     .legislation-content > aside:first-of-type > div {border: 0.125rem dashed var(--alert)}
                 }
@@ -3560,7 +3579,7 @@ body:not(:-moz-handler-blocked) fieldset {
 					&:has(> details[open]) {
 						h2 {.sr-only()}
 						> details > summary {
-							background: var(--buttonBg); position: absolute; width: 2.5rem; height: 12.5rem;
+							background: var(--buttonBg); position: absolute; width: 2.5rem; height: 12.5rem; z-index: 30;
 							&:hover, &:focus {.button-focus()}
 							> span {
 								&:before {display: none}
@@ -3571,14 +3590,23 @@ body:not(:-moz-handler-blocked) fieldset {
 						}
 						.versions {
 							ol {
-								flex-flow: row; overflow-x: auto; overflow-y: hidden; margin: 0 16rem 0 2.5rem; width: calc(100% - 18.5rem); height: 12.5rem; background: var(--verySubtleBg);
+								flex-flow: row; overflow-x: auto; overflow-y: hidden; margin: 0 16rem; width: calc(100% - 32rem); height: 12.5rem; background: var(--verySubtleBg);
 								&::-webkit-scrollbar {margin: 0; display: none}
-								&:before {content: ""; background: var(--timelineVersion); width: calc(var(--maxWidth) - 40.75rem); height: 0.5rem; position: absolute; margin: 6.05rem 0 0 20.25rem}
+								&:before {content: ""; background: var(--timelineVersion); width: calc(var(--maxWidth) - 20rem); height: 0.5rem; position: absolute; margin: 6.05rem 0 0 -6rem}
 								&:has(li:nth-of-type(2) .previous-point-in-time):before {width: calc(var(--maxWidth) - 44rem); margin: 6.05rem 0 0 26rem}
 								&:has(li:last-of-type .point-in-time):before {width: calc(var(--maxWidth) - 44.25rem)}
-								&:has(li:last-of-type[aria-current="page"]):before {background: var(--timelineVersionActive)}
+								&:has(li:last-of-type[aria-current="page"])
+								{
+									&:before {background: var(--timelineVersionActive)}
+									&:has(li:first-of-type > div) {
+										&:before {background: var(--lessSubtleBorder)}
+										li:first-of-type {											
+											.version:after {border-color: transparent}
+										}
+										li.consolidated a:before {left: -0.5rem}
+									}
+								}
 								&:has(li:last-of-type:nth-of-type(2)) {
-									&:before {display: none}
 									li > a .version:before {border-color: transparent}
 								}
 								
@@ -3611,21 +3639,15 @@ body:not(:-moz-handler-blocked) fieldset {
 										}
 									}
 									&:first-of-type {
-										background: var(--verySubtleBg); margin: 0 0.5rem 0 0;
+										background: var(--verySubtleBg); margin: 0 0 0 -16rem; z-index: 20; position: absolute;
 										> a, > div {
-											width: 13.5rem;
+											padding: 2.05rem 0 0 2.4rem; width: 16rem;
 											.version {
 												&:before, &:after {border-color: transparent}
 											}
-											.date:before {background: var(--bg) var(--timelineEnactedVersionIcon); background-size: 55%; width: 3.15rem; height: 3.15rem; border-radius: 50%; margin: -1.8rem auto 0.8rem auto; }
+											.date:before {background: var(--bg) var(--timelineVersionIcon); background-size: 40%; width: 3.15rem; height: 3.15rem; border-radius: 50%; margin: -1.8rem auto 0.8rem auto}
 										}
-										> div .date:before {border: 0.2rem solid var(--subtleBorder)}
-										&[aria-current="page"] {
-											> a .version {
-												&:before {border-color: transparent}
-												&:after {border-color: transparent}
-											}
-										}
+										> div .date:before {border: 0.2rem solid var(--lessSubtleBorder)}
 									}
 									&:nth-of-type(2) {
 										> a, > div {
@@ -3633,7 +3655,7 @@ body:not(:-moz-handler-blocked) fieldset {
 										}
 									}
 									&:last-of-type {
-										position: absolute; width: 16rem; margin: 0 0 0 calc(var(--maxWidth) - 20.5rem); background: var(--verySubtleBg);
+										position: absolute; width: 16rem; margin: 0 0 0 calc(var(--maxWidth) - 34rem); background: var(--verySubtleBg);
 										> a {
 											padding: 2.05rem 0 0 2.5rem; width: 16rem;
 											.version {
@@ -3677,19 +3699,26 @@ body:not(:-moz-handler-blocked) fieldset {
 											+ li .version:before {margin: 4rem 50% -4rem 0}
 										}
 										+ li .version:before {margin: 4rem 50% -4rem -3.75rem}
+										&:first-of-type > a {padding: 2.05rem 5.5rem 0 2.9rem; width: 21rem}
 									}
-
+									
 									&:not([aria-current="page"]) {
 										&:hover, &:focus {
 											> a {
 												color: var(--link);
-												.date:before {.button-focus(); outline: 0; background: var(--buttonBg) var(--timelineVersionIconHover); background-size: 40%}
+												.date:before {.button-focus(); outline: 0; background: var(--focusButtonBg) var(--timelineVersionIconHover); background-size: 40%}
 											}
 										}
 									}
+
 									&:first-of-type:not([aria-current="page"]) {
-										&:hover, &:focus {
-											> a .date:before {background: var(--buttonBg) var(--timelineEnactedVersionIconHover); background-size: 55%}
+										> a, > div {
+											.version:after {border-color: var(--timelineVersionActive)}
+										}
+									}
+									&:first-of-type:not([aria-current="page"]) ~ :nth-of-type(2) {
+										> a, > div {
+											.version:before {border-color: var(--timelineVersionActive)}
 										}
 									}
 
@@ -3707,7 +3736,6 @@ body:not(:-moz-handler-blocked) fieldset {
 												&:before {border: 0.2rem solid var(--timelineVersionActive); background: var(--timelineVersionActive) var(--timelineVersionIconActive); background-size: 40%}
 											}
 										}
-										&:first-of-type > a .date:before {background: var(--timelineVersionActive) var(--timelineEnactedVersionIconActive); background-size: 55%}
 										~ li:not(:last-of-type ) {
 											> a, > div {
 												.version {
@@ -3721,6 +3749,7 @@ body:not(:-moz-handler-blocked) fieldset {
 											}
 										}
 									}
+									&[aria-current="page"] ~ li:nth-of-type(2) > a .version:before {border-color: var(--timelineVersion)}
                                     &.prospective {
                                         > a .date:before {border-color: var(--alert)}
                                         &[aria-current="page"] {
@@ -3737,9 +3766,15 @@ body:not(:-moz-handler-blocked) fieldset {
                                             }
 
                                     }
-                                    &.consolidated {
-                                        a:before {content: ""; display: block; width: 1.65rem; height: 2.35rem; border: 0; border-radius: 0; cursor: auto; background-color: unset; background-position: 0 0; background-repeat: no-repeat; position: absolute; left: -0.8rem; top: calc(50% - (2.125rem / 2)); z-index: 1}
+									&.consolidated {
+										> a, > div {
+											padding: 2.05rem 0 0 2.5rem;
+											.version:before {margin: 4rem 50% -4rem -2.5rem}
+										}
+                                        a:before {content: ""; display: block; width: 1.65rem; height: 2.35rem; border: 0; border-radius: 0; cursor: auto; background-color: unset; background-position: 0 0; background-repeat: no-repeat; position: absolute; left: 1rem; top: calc(50% - (2.125rem / 2)); z-index: 1}
+										.explanation {.sr-only}
                                     }
+									
 									details {
 										&:not([open]) {
 											summary {
@@ -3772,26 +3807,97 @@ body:not(:-moz-handler-blocked) fieldset {
 										details[open] summary, div {left: 0.5rem}
 									}
 								}
-								&:has(li:last-of-type .point-in-time) {
-									width: calc(100% - 22rem);
-									li:last-of-type {
-										width: 19.5rem; margin: 0 0 0 calc(var(--maxWidth) - 24rem);
+								&:has(li:first-of-type .point-in-time) {
+									margin: 0 16rem 0 22rem; width: calc(100% - 38rem);
+									&:before {width: calc(var(--maxWidth) - 25rem)}
+									li:first-of-type {
+										margin: 0 0 0 -22rem;
 										> a {
-											padding: 2.05rem 9rem 0 0; width: 21.5rem;
-											.version:before {margin: 4rem 50% -4rem 0}
-											.point-in-time {right: 1.35rem}
+											padding: 2.05rem 6.5rem 0 2.9rem; width: 22rem;
+											.version:after {margin: 2.2rem -2rem 0 50%}
+											.point-in-time {right: 1rem}
 										}
-										&:has(.previous-point-in-time) {
+									}
+									li:last-of-type {margin: 0 0 0 calc(var(--maxWidth) - 40rem)}
+								}
+								&:has(li:last-of-type .point-in-time) {
+									&:before {width: calc(var(--maxWidth) - 33.25rem)}
+									li:last-of-type {
+										margin: 0 0 0 calc(var(--maxWidth) - 23.3rem); width: 18rem; background: unset;
+										&:first-of-type {
+											margin: 0 0 0 calc(var(--maxWidth) - 26.25rem);
 											> a {
-												padding: 2.05rem 0 0 7.5rem; width: 18rem;
-												.version {
-													&:before {border-top: 0.5em dashed var(--timelineVersionActive); margin: 4rem 50% -4rem -2rem}
-													&:after {border-top-color: transparent; margin: 2.2rem 0 0 50%}
-												}
-												.point-in-time {left: 0.75rem; right: unset}
+												.point-in-time {right: 3.1rem}
 											}
-											+ li .version:before {margin: 4rem 50% -4rem 0}
 										}
+									}
+								}
+								&:not(:has(li:nth-child(3))):has(li:nth-child(2)):has(li:first-of-type .previous-point-in-time)
+								{
+									&:before {width: calc(var(--maxWidth) - 25rem); margin: 6.05rem 0 0 16rem}
+									li:first-of-type {
+										> a {
+											padding: 2.05rem 0 0 10rem;
+											.version:before {border-style: solid}
+											.version:after {border-color: transparent}
+											.previous-point-in-time {right: unset; left: 4.5rem}
+										}
+									}
+									
+								}
+								&:has(li:last-of-type .previous-point-in-time) {
+									&:before {width: calc(var(--maxWidth) - 25rem)}
+									li:last-of-type {
+										margin: 0 0 0 calc(var(--maxWidth) - 20.875rem);
+										> a {
+											.version:after {border-color: transparent}
+										}
+									}
+									
+								}
+								&:has(li:first-of-type:last-of-type .previous-point-in-time) {
+									&:before {width: calc(var(--maxWidth) - 18rem)}
+									li:last-of-type {
+										&:before {display: none}
+										margin: 0 0 0 calc(var(--maxWidth) - 20rem);
+											width: 16rem;
+										> a {
+											padding: 2.05rem 0 0 2.5rem;
+											width: 16rem;
+											.version:before {border-color: transparent}
+											.version:after {border-color: transparent}
+											.previous-point-in-time {right: unset; left: 4.5rem}
+										}
+									}
+									
+								}
+								&:not(:has(li:nth-child(3))):has(li:nth-child(2)) {
+									width: 100%; margin: 0;
+									&:before {margin: 6.05rem 0 0 8rem}
+									li:first-of-type {position: relative; margin: 0; background: unset}
+									li:last-of-type:not(:has(.point-in-time)) {margin: 0 0 0 calc(var(--maxWidth) - 18rem); background: unset}
+									&:has(.prospective) li:first-of-type .version:after {border-color: transparent}
+								}
+								&:has(li:first-of-type:last-of-type) {
+									width: 100%; margin: 0; position: relative;
+									&:before {margin: 6.05rem 0 0 8rem}
+									li {
+										position: unset; margin: 0 0 0 calc(var(--maxWidth) - 18rem); background: unset;
+										&:before {content: ""; background: var(--timelineVersionActive); width: 1.65rem; height: 1.65rem; position: absolute; margin: 5.4rem 7.25rem; border-radius: 50%; left: 0}
+									}
+								}
+								&:not(:has(li[aria-current="page"])) {
+									li:not(:last-of-type),
+									li:not(:last-of-type) ~ li,
+									li:not(:last-of-type) ~ :nth-of-type(2):not(:last-of-type),
+									li:last-of-type {
+										> a .version {
+											&:before, &:after {border-color: transparent}
+										}
+									}
+									li:first-of-type:not([aria-current="page"]) ~ :nth-of-type(2),
+									li:last-of-type {
+										> a .version:before {border-color: var(--timelineVersion)}
 									}
 								}
 							}
@@ -3812,10 +3918,21 @@ body:not(:-moz-handler-blocked) fieldset {
 								}
 								.scrollbar {.scrollbar-controls}
 							}
-						}
+						}						
 						&:has(.scrollable) {
 							> details summary {height: 16rem}
 							.versions details:not([open]) summary {top: calc(50% - 2.75rem)}
+							.versions ol li:first-of-type:before {float: right; content: ""; overflow: hidden; display: block; margin:  0 -0.5em 0 0; position: unset; width: 0.4rem; height: 16rem; z-index: unset; background: linear-gradient(270deg, var(--dropShadowStart) 0%, var(--dropShadowEnd) 100%)}
+							.scrollable .versions .scrollbar {margin: -4rem 0 0 16rem; width: calc(100% - 32rem)}
+						}
+						&:has(ol li:first-of-type .point-in-time) {
+							.scrollable {
+								.versions {
+									.scrollbar {
+										margin: -4rem 0 0 22rem; width: calc(100% - 38rem);
+									}
+								}
+							}
 						}
 						&:has(ol li:last-of-type .point-in-time) {
 							.scrollable {
@@ -3871,10 +3988,8 @@ body:not(:-moz-handler-blocked) fieldset {
 								p:first-of-type {background-position: 0.5rem 0.45rem; background-size: 1rem}
 							}
 							&.up-to-date ul {.toggle; margin: 0 1em 0.75em 1em}
+							&.contributed p {padding: 0.5em 1em}
 						}
-
-                        
-                        
                         details {
                             margin: 0;
                             summary {padding: 0.8em 0 0.8em 1em; text-align: unset}
@@ -4306,8 +4421,7 @@ body:not(:-moz-handler-blocked) fieldset {
             &.language {background-position: 1.15em 0.45em; background-size: 1.1em}
             &.up-to-date {background-position: 1.15rem 0.45rem; background-size: 1.1rem}
             &.dated-version {background-position: 1.15rem 0.45rem; background-size: 1.1rem}
-            &.as-enacted-formats {background-position: 1.15rem 0.45rem; background-size: 1.1rem}
-            &.as-enacted-formats.pdf {background-position: 1.15rem 0.45rem; background-size: 1.1rem}
+            &.as-enacted.pdf {background-position: 1.15rem 0.45rem; background-size: 1.1rem}
             &.extent, &.in-force {background-position: 1rem 0.45rem; background-size: 1.25rem}
             &.blanket-amendments {background-position: 0.9rem 0.45rem; background-size: 1.25rem}
             &.confers-power {background-position: 1.15rem 0.45rem; background-size: 0.8rem}
@@ -4316,8 +4430,7 @@ body:not(:-moz-handler-blocked) fieldset {
             &.language {background-position: 0.5rem 0.45rem; background-size: 1.1em}
             &.up-to-date {background-position: 0.5rem 0.45rem; background-size: 1.1rem}
             &.dated-version {background-position: 0.5rem 0.45rem; background-size: 1.1rem}
-            &.as-enacted-formats {background-position: 0.5rem 0.45rem; background-size: 1.1rem}
-            &.as-enacted-formats.pdf {background-position: 0.5rem 0.45rem; background-size: 1.1rem}
+            &.as-enacted.pdf {background-position: 0.5rem 0.45rem; background-size: 1.1rem}
             &.extent, &.in-force {background-position: 0.4rem 0.45rem; background-size: 1.25rem}
             &.blanket-amendments {background-position: 0.25rem 0.45rem; background-size: 1.25rem}
             &.confers-power {background-position: 0.5rem 0.45rem; background-size: 0.8rem}
@@ -4343,3 +4456,101 @@ body:not(:-moz-handler-blocked) fieldset {
     }
 
 body:has(.advanced-searches) header .hdr-search {display: none}
+
+// dev environment only - to compare 'one-original' and 'two-originals' timelines
+	.main-menu ul li button {
+		.ghost-button; padding: 0.1rem 0.5em;
+		&:first-of-type {margin: 0 0.5rem 0 0}
+		&.selected {background: var(--activeBg); color: var(--activeText); border-color: var(--activeBg)}
+	}
+
+	:root[timeline-mode="one-original"] {/*
+		@media print and (orientation: portrait), screen and (max-width: calc(1023px - 1px)) {
+			main.legislation .timeline:has(> details[open]) details .versions ol {
+				li {
+					&:first-of-type {border-color: var(--modalTimelinePast)}
+					&:last-of-type {
+						padding: 0;
+						a {padding: 0 0 0 1.25rem}
+					}
+					&.consolidated {
+						&:before {z-index: 1; top: 1.75rem}
+						a {
+							padding: 1.5rem 0 1rem 1.25rem;
+							&:before {content: ""; top: -0.25rem; left: -0.2rem; background: var(--modalTimelinePast); width: 0.2rem}
+							&:after {content: ""; display: block; height: 2rem; width: 1rem; position: absolute; left: -0.6rem; top: -0.75rem; background-image: url(images/timeline-break.png); background-repeat: no-repeat; background-size: 1rem}
+						}
+						.explanation {margin: -0.75rem 0 0.75rem 1.25rem; font-style: italic; font-weight: 300}
+						&:last-of-type {
+							a {padding: 1.5rem 0 0 1.25rem}
+							.explanation {margin: 0.25rem 0 0.75rem 1.25rem}
+						}
+					}
+				}
+			}
+		}
+		
+		@media print and (orientation: landscape), screen and (min-width: 1024px) {
+			main.legislation .timeline {
+				&:has(> details[open]) {
+					> details summary {z-index: 30}
+					.versions ol {
+						margin: 0 16rem; width: calc(100% - 32rem);
+						&:before {width: calc(var(--maxWidth) - 20rem); margin: 6.05rem 0 0 -6rem}
+						&:has(li:last-of-type:nth-of-type(2)) {
+							&:before {display: block}
+						}
+						li {
+							&[aria-current="page"] ~ li:nth-of-type(2) > a .version:before {border-color: var(--timelineVersion)}
+							&:first-of-type {
+								margin: 0 0 0 -16rem; z-index: 20; position: absolute;
+								> a, > div {
+									padding: 2.05rem 0 0 2.4rem; width: 16rem;
+									.date:before {background: var(--bg) var(--timelineVersionIcon); background-size: 40%}
+								}
+								&[aria-current="page"] .date:before {border: 0.2rem solid var(--timelineVersionActive); background: var(--timelineVersionActive) var(--timelineVersionIconActive); background-size: 40%;}
+							}
+							&:not([aria-current="page"]):hover > a .date:before {
+								color: var(--buttonText); border-color: var(--focusOutline); text-decoration: none; -webkit-box-shadow: 0 0 0.375rem 0 var(--focusShadow); -moz-box-shadow: 0 0 0.375rem 0 var(--focusShadow); box-shadow: 0 0 0.375rem 0 var(--focusShadow); outline: 0; background: var(--focusButtonBg) var(--timelineVersionIconHover); background-size: 40%;
+							}
+							&:first-of-type:not([aria-current="page"]) > a .version:after, 
+							&:first-of-type:not([aria-current="page"]) > div .version:after,
+							&:first-of-type:not([aria-current="page"]) ~ :nth-of-type(2) > a .version:before,
+							&:first-of-type:not([aria-current="page"]) ~ :nth-of-type(2) > div .version:before
+							{
+								border-color: var(--timelineVersionActive)
+							}
+							&:last-of-type {margin: 0 0 0 calc(var(--maxWidth) - 34rem)}
+							&.consolidated {
+								> a, > div {
+									padding: 2.05rem 0 0 2.5rem;
+									.version:before {margin: 4rem 50% -4rem -2.5rem}
+								}					
+								a:before {left: 1rem}
+								.explanation {.sr-only}
+							}
+						}
+						&:not(:has(li:nth-child(4))):has(li:nth-child(3)) {
+							margin: 0 16rem 0 0; width: calc(100% - 16rem);
+							&:before {margin: 6.05rem 0 0 8rem}
+							li:first-of-type {position: relative; margin: 0; background: unset}
+							li:last-of-type {margin: 0 0 0 calc(var(--maxWidth) - 18rem)}
+							&:has(.prospective) li:first-of-type .version:after {border-color: transparent}
+						}
+						&:has(li:nth-of-type(2):last-of-type) {
+        					width: calc(100% - 16rem);
+							li:last-of-type {position: relative; background: unset}
+							&:has(li:first-of-type.current) {
+								li:first-of-type a:before {content: ""; display: block; width: 1.65rem; height: 1.65rem; margin: 3.45rem auto 1.75rem auto; border-radius: 50%; background: var(--timelineVersionActive)}
+							}
+						}
+					}
+				}
+				&:has(.scrollable):has(> details[open]) {
+					.versions ol li:first-of-type:before {float: right; content: ""; overflow: hidden; display: block; margin:  0 -0.5em 0 0; position: unset; width: 0.4rem; height: 16rem; z-index: unset; background: linear-gradient(270deg, var(--dropShadowStart) 0%, var(--dropShadowEnd) 100%)}
+					.scrollable .versions .scrollbar {margin: -4rem 0 0 16rem; width: calc(100% - 32rem)}
+				}
+			}
+		}
+	*/}
+// End dev environment only

--- a/lgu2/templates/new_theme/document/document.html
+++ b/lgu2/templates/new_theme/document/document.html
@@ -37,7 +37,7 @@
         <details>
             <summary>
                 You are viewing {% if meta.fragmentInfo %}{{ meta.fragmentInfo.label }}{% else %}this legislation{% endif %} on <span>{{ view_date|date:'d M Y' }}</span>
-                <span> Enter a date or choose from the versions on the timeline</span>
+                <span> Enter a date{% if timeline %} or choose from the versions on the timeline{% endif %}</span>
             </summary>
             <form role="search">
                 <h3>Change the date</h3>

--- a/lgu2/templates/new_theme/document/timeline.html
+++ b/lgu2/templates/new_theme/document/timeline.html
@@ -5,20 +5,31 @@
             <span class="open">
                 <span class="version">
                     <span class="prefix">You are viewing </span>
-                    {% if timeline.original and timeline.original.label == timeline.viewing.label %}
-                    <span class="title">the original version</span>
-                    {% elif timeline.current and timeline.current.label == timeline.viewing.label %}
-                        {% if timeline.current.label == 'prospective'%}
+                    {% if timeline.viewing.label == timeline.current.label %}
+                        {% if timeline.current.label == 'prospective' %}
                             <span class="title">a prospective version</span>
+                        {% elif timeline.current.label == 'enacted' or timeline.current.label == 'made' or timeline.current.label == 'created' or timeline.current.label == 'adopted' %}
+                            <span class="title">the original version</span>
                         {% else %}
                             <span class="title">the current version</span>
                         {% endif %}
                     {% else %}
-                    <span class="title">a historical version</span>
+                        <span class="title">a historical version</span>
                     {% endif %}
                 </span>
                 {% if timeline.viewing.label == 'prospective' %}
                     <span class="date">not yet in force</span>
+                {% elif timeline.viewing.label == 'enacted' or timeline.viewing.label == 'made' or timeline.viewing.label == 'created' or timeline.viewing.label == 'adopted' %}
+                    {% if timeline.viewing.date %}
+                        <span class="date">as {{ timeline.viewing.label }} on <span>{{ timeline.viewing.date|date:'d F Y' }}</span></span>
+                    {% else %}
+                        <span class="date" aria-hidden="true">{# this is necessary for the icon to appear #}</span>
+                    {% endif %}
+                    {% if timeline.pointInTime %}
+                        <span class="point-in-time{% if timeline.viewing.date and timeline.pointInTime < timeline.viewing.date %} previous-point-in-time{% endif %}">
+                            as it was on <span>{{ timeline.pointInTime|date:'d F Y' }}</span>
+                        </span>
+                    {% endif %}
                 {% else %}
                     {% if timeline.viewing.date %}
                         <span class="date">from <span>{{ timeline.viewing.date|date:'d F Y' }}</span></span>
@@ -38,48 +49,14 @@
         <div class="versions">
             <nav aria-label="Timeline of versions">
                 <ol>
-                    {% if timeline.original %}
-                        {% if timeline.original.label == timeline.viewing.label %}
-                        <li aria-current="page">
-                            <a href="javascript:void(0);">
-                                <span class="prefix">You are viewing </span>
-                                <span class="version"><span class="title">the original version</span></span>
-                                {% if timeline.original.date %}
-                                    <span class="date">as {{ timeline.original.label }} on <span>{{ timeline.original.date|date:'d F Y' }}</span></span>
-                                {% else %}
-                                    <span class="date" aria-hidden="true">{# this is necessary for the icon to appear #}</span>
-                                {% endif %}
-                                {% if timeline.pointInTime %}
-                                    {% if not timeline.original.date or timeline.pointInTime != timeline.original.date %}
-                                    <span class="point-in-time{% if timeline.original.date and timeline.pointInTime < timeline.original.date %} previous-point-in-time{% endif %}">
-                                        as it was on <span>{{ timeline.pointInTime|date:'d F Y' }}</span>
-                                    </span>
-                                    {% endif %}
-                                {% endif %}
-                            </a>
-                        </li>
-                        {% else %}
-                        <li>
-                            <a href="{{ timeline.original.link }}">
-                                <span class="version"><span class="title">The original version</span></span>
-                                {% if timeline.original.date %}
-                                    <span class="date">as {{ timeline.original.label }} on <span>{{ timeline.original.date|date:'d F Y' }}</span></span>
-                                {% else %}
-                                    <span class="date" aria-hidden="true">{# this is necessary for the icon to appear #}</span>
-                                {% endif %}
-                            </a>
-                        </li>
-                        {% endif %}
-                    {% endif %}
-
-                    {% for v in timeline.historical %}
+                    {% for v in timeline.entries %}
                         {% if v.label == timeline.viewing.label %}
                         <li aria-current="page">
                             <a href="javascript:void(0);">
                                 <span class="prefix">You are viewing </span>
                                 <span class="version"><span class="title">a historical version</span></span>
                                 <span class="date">from <span>{{ v.date|date:'d F Y' }}</span></span>
-                                {% if timeline.pointInTime and timeline.pointInTime != v.date  %}
+                                {% if timeline.pointInTime and timeline.pointInTime != v.date %}
                                     <span class="point-in-time{% if timeline.pointInTime < v.date %} previous-point-in-time{% endif %}">
                                         as it was on <span>{{ timeline.pointInTime|date:'d F Y' }}</span>
                                     </span>
@@ -88,7 +65,7 @@
                         </li>
                         {% else %}
                         <li>
-                            <a href="{{ v.link}}">
+                            <a href="{{ v.link }}">
                                 <span class="version"><span class="title">A historical version</span></span>
                                 <span class="date">from <span>{{ v.date|date:'d F Y' }}</span></span>
                             </a>
@@ -96,7 +73,7 @@
                         {% endif %}
                     {% endfor %}
 
-                    {% if timeline.current and timeline.current.label == 'prospective' %}{# prospective #}
+                    {% if timeline.current.label == 'prospective' %}
                         {% if timeline.current.label == timeline.viewing.label %}
                         <li aria-current="page">
                             <a href="javascript:void(0);">
@@ -117,13 +94,32 @@
                             </a>
                         </li>
                         {% endif %}
-                    {% elif timeline.current %}{# not prospective #}
+                    {% elif timeline.current.label == 'enacted' or timeline.current.label == 'made' or timeline.current.label == 'created' or timeline.current.label == 'adopted' %}
+                        <li aria-current="page">
+                            <a href="javascript:void(0);">
+                                <span class="prefix">You are viewing </span>
+                                <span class="version"><span class="title">the original version</span></span>
+                                {% if timeline.current.date %}
+                                    <span class="date">as {{ timeline.current.label }} on <span>{{ timeline.current.date|date:'d F Y' }}</span></span>
+                                {% else %}
+                                    <span class="date" aria-hidden="true">{# this is necessary for the icon to appear #}</span>
+                                {% endif %}
+                                {% if timeline.pointInTime %}
+                                    {% if not timeline.current.date or timeline.pointInTime != timeline.current.date %}
+                                    <span class="point-in-time{% if timeline.current.date and timeline.pointInTime < timeline.current.date %} previous-point-in-time{% endif %}">
+                                        as it was on <span>{{ timeline.pointInTime|date:'d F Y' }}</span>
+                                    </span>
+                                    {% endif %}
+                                {% endif %}
+                            </a>
+                        </li>
+                    {% else %}
                         {% if timeline.current.label == timeline.viewing.label %}
                         <li aria-current="page">
                             <a href="javascript:void(0);">
                                 <span class="version">
                                     <span class="prefix">You are viewing </span>
-                                    <span class="title">the current version</span>                                    
+                                    <span class="title">the current version</span>
                                 </span>
                                 <span class="date">from <span>{{ timeline.current.date|date:'d F Y' }}</span></span>
                                 {% if timeline.pointInTime and timeline.pointInTime != timeline.current.date %}
@@ -146,7 +142,7 @@
                     {% endif %}
                 </ol>
             </nav>
-                <div hidden class="scrollbar initialise">
+            <div hidden class="scrollbar initialise">
                 <h3>Scrollbar to access all versions on the timeline. Keyboard-only users already have access to all versions.</h3>
                 <button class="left" disabled><span>Scroll left</span></button>
                 <div class="drag-strip"><div class="drag" draggable="true"><span>Drag horizontally to scroll timeline</span></div></div>

--- a/lgu2/templates/new_theme/document/toc.html
+++ b/lgu2/templates/new_theme/document/toc.html
@@ -30,8 +30,6 @@
         </details>
     </section>
 
-    {% include "new_theme/document/timeline.html" %}
-
     <div class="legislation-content">
         {% include "new_theme/document/right_side_panel.html" %}
 

--- a/lgu2/tests/test_document_views.py
+++ b/lgu2/tests/test_document_views.py
@@ -180,6 +180,7 @@ class TocViewTests(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Printer Version')
         self.assertContains(response, 'received Royal Assent when it was enacted')
+        self.assertNotContains(response, 'class="timeline"')
 
     @patch("lgu2.views.toc.api.get_toc")
     def test_toc_pdf_only_revised_omits_kings_printer_message(self, mock_get_toc):

--- a/lgu2/tests/util/test_timeline.py
+++ b/lgu2/tests/util/test_timeline.py
@@ -22,7 +22,6 @@ class DocumentTimelineTests(SimpleTestCase):
         timeline = make_timeline_data(meta, 'document')
         current = timeline['current']
 
-        self.assertIsNotNone(current)
         self.assertIsNone(current['date'])
         self.assertEqual(
             current['link'],
@@ -87,43 +86,80 @@ class FragmentTimelineTests(SimpleTestCase):
         }
 
         timeline = make_timeline_data(meta, 'fragment')
-        historical = timeline['historical']
+        entries = timeline['entries']
 
-        self.assertEqual(len(historical), 1)
-        entry = historical[0]
+        self.assertEqual(len(entries), 1)
+        entry = entries[0]
         self.assertEqual(entry['label'], '2022-01-01')
         self.assertEqual(
             entry['link'],
             reverse('fragment-version', args=['ukpga', 2023, 1, 'section/1', '2022-01-01'])
         )
-        # The current (latest) version is shown without the version suffix.
         self.assertEqual(
             timeline['viewing']['link'],
             reverse('fragment', args=['ukpga', 2023, 1, 'section/1'])
         )
 
 
-class TocTimelineTests(SimpleTestCase):
+class TimelineVisibilityTests(SimpleTestCase):
 
-    def test_toc_timeline_includes_original_entry(self):
+    def test_single_enacted_version(self):
         meta = {
             'shortType': 'ukpga',
             'year': 2023,
             'number': 1,
-            'versions': ['enacted', '2022-01-01'],
-            'version': '2022-01-01',
+            'versions': ['enacted'],
+            'version': 'enacted',
             'date': date(2018, 6, 20),
         }
+        timeline = make_timeline_data(meta, 'document')
+        self.assertIsNotNone(timeline)
+        self.assertEqual(timeline['current']['label'], 'enacted')
+        self.assertEqual(timeline['entries'], [])
+        self.assertTrue(timeline['single_version'])
 
-        timeline = make_timeline_data(meta, 'toc')
-        original = timeline['original']
+    def test_multiple_versions_viewing_enacted_returns_none(self):
+        meta = {
+            'shortType': 'ukpga',
+            'year': 2023,
+            'number': 1,
+            'versions': ['enacted', '2024-01-01'],
+            'version': 'enacted',
+            'date': date(2018, 6, 20),
+        }
+        timeline = make_timeline_data(meta, 'document')
+        self.assertIsNone(timeline)
 
-        self.assertIsNotNone(original)
-        self.assertEqual(original['label'], 'enacted')
-        self.assertEqual(
-            original['link'],
-            reverse('toc-version', args=['ukpga', 2023, 1, 'enacted'])
-        )
+    def test_multiple_versions_viewing_dated(self):
+        meta = {
+            'shortType': 'ukpga',
+            'year': 2023,
+            'number': 1,
+            'versions': ['enacted', '2022-01-01', '2024-01-01'],
+            'version': '2024-01-01',
+            'date': date(2018, 6, 20),
+        }
+        timeline = make_timeline_data(meta, 'document')
+        self.assertIsNotNone(timeline)
+        labels = [e['label'] for e in timeline['entries']]
+        self.assertNotIn('enacted', labels)
+        self.assertEqual(labels, ['2022-01-01'])
+        self.assertEqual(timeline['current']['label'], '2024-01-01')
+
+    def test_two_versions_enacted_plus_date(self):
+        meta = {
+            'shortType': 'ukpga',
+            'year': 2023,
+            'number': 1,
+            'versions': ['enacted', '2024-01-01'],
+            'version': '2024-01-01',
+            'date': date(2018, 6, 20),
+        }
+        timeline = make_timeline_data(meta, 'document')
+        self.assertIsNotNone(timeline)
+        self.assertEqual(timeline['entries'], [])
+        self.assertEqual(timeline['current']['label'], '2024-01-01')
+        self.assertTrue(timeline['single_version'])
 
 
 class TimelineTemplateTests(SimpleTestCase):
@@ -162,12 +198,12 @@ class TimelineTemplateTests(SimpleTestCase):
         self.assertIn('class="point-in-time"', html)
         self.assertIn('01 June 2023', html)
 
-    def test_template_uses_original_label_in_original_entry(self):
+    def test_template_uses_original_label_for_sole_version(self):
         meta = {
             'shortType': 'ukpga',
             'year': 2023,
             'number': 1,
-            'versions': ['made', '2022-01-01'],
+            'versions': ['made'],
             'version': 'made',
             'date': date(2018, 6, 20),
         }

--- a/lgu2/util/timeline.py
+++ b/lgu2/util/timeline.py
@@ -14,9 +14,8 @@ class TimelineEntry(TypedDict):
 
 
 class TimelineData(TypedDict):
-    original: Optional[TimelineEntry]
-    current: Optional[TimelineEntry]
-    historical: List[TimelineEntry]
+    entries: List[TimelineEntry]
+    current: TimelineEntry
     viewing: TimelineEntry
     pointInTime: Optional[date]
     single_version: bool
@@ -27,28 +26,18 @@ _ISO_DATE_RE = re.compile(r'\d{4}-\d{2}-\d{2}')
 
 def make_timeline_data(
     meta: Union[DocumentMetadata, FragmentMetadata, CommonMetadata],
-    target: str,  # 'document', 'fragment', or 'toc'
+    target: str,  # 'document' or 'fragment'
     lang: Optional[str] = None,
-) -> TimelineData:
-    """
-    Generic function to build timeline data for documents, fragments, or TOCs.
-
-    Refactoring justification:
-    - Removes near-identical code repeated across three functions.
-    - Makes adding new targets (e.g. 'appendix') trivial.
-    - Centralizes URL logic for maintainability.
-    """
+) -> Optional[TimelineData]:
 
     def make_link(version: Optional[str]) -> str:
         year: Union[int, str] = meta['regnalYear'] if 'regnalYear' in meta else meta['year']
 
         args = [meta['shortType'], year, meta['number']]
 
-        # Fragment timelines include the fragment href before optional version/lang args
         if target == 'fragment':
             args.append(meta['fragmentInfo']['href'])
 
-        # Build route name dynamically
         suffix = ""
         if version:
             suffix += "-version"
@@ -56,7 +45,6 @@ def make_timeline_data(
             suffix += "-lang"
         route_name = f"{target}{suffix}"
 
-        # Append version if needed
         if version:
             args.append(version)
         if lang:
@@ -67,48 +55,56 @@ def make_timeline_data(
     return _make_timeline_data(meta, make_link)
 
 
-def _make_timeline_data(meta: CommonMetadata, make_link: Callable) -> TimelineData:
+def _make_timeline_data(meta: CommonMetadata, make_link: Callable) -> Optional[TimelineData]:
     versions = meta['versions'].copy()
     point_in_time = meta.get("pointInTime")
 
-    original = None
+    held_aside = None
     if versions and not _ISO_DATE_RE.fullmatch(versions[0]) and versions[0] != 'prospective':
-        version = versions.pop(0)
-        original = {
-            'label': version,
+        label = versions.pop(0)
+        held_aside = {
+            'label': label,
             'date': meta.get('date'),
-            'link': make_link(version),
         }
 
-    current = None
-    if versions:
-        version = versions.pop(-1)
+    if not versions:
         current = {
-            'label': version,
-            'date': None if version == 'prospective' else date.fromisoformat(version),
+            'label': held_aside['label'],
+            'date': held_aside['date'],
             'link': make_link(None),
         }
+        return {
+            'entries': [],
+            'current': current,
+            'viewing': current,
+            'pointInTime': point_in_time,
+            'single_version': True,
+        }
 
-    historical = [
+    if held_aside and held_aside['label'] == meta['version']:
+        return None
+
+    current_label = versions.pop(-1)
+    current = {
+        'label': current_label,
+        'date': None if current_label == 'prospective' else date.fromisoformat(current_label),
+        'link': make_link(None),
+    }
+
+    entries = [
         {'label': v, 'date': date.fromisoformat(v), 'link': make_link(v)}
         for v in versions
     ]
 
-    viewing = None
-    if original and original['label'] == meta['version']:
-        viewing = original
-    elif current and current['label'] == meta['version']:
+    if current['label'] == meta['version']:
         viewing = current
     else:
-        viewing = next(v for v in historical if v['label'] == meta['version'])
-
-    version_count = (1 if original else 0) + len(historical) + (1 if current else 0)
+        viewing = next(v for v in entries if v['label'] == meta['version'])
 
     return {
-        'original': original,
-        'historical': historical,
+        'entries': entries,
         'current': current,
         'viewing': viewing,
         'pointInTime': point_in_time,
-        'single_version': version_count == 1,
+        'single_version': len(entries) == 0,
     }

--- a/lgu2/views/toc.py
+++ b/lgu2/views/toc.py
@@ -13,7 +13,6 @@ from ..util.extent import make_combined_extent_label
 from ..util.labels import get_type_label
 from ..util.links import make_contents_link, make_document_link, make_fragment_link
 from .redirect import make_data_redirect
-from ..util.timeline import make_timeline_data
 from ..status import for_document
 from ..util.dated_version import dated_version_panel, is_most_recent_version
 from .helper.status import make_pdf_status_message
@@ -92,8 +91,6 @@ def toc(request, type: str, year: str, number: str, version: Optional[str] = Non
         data['pdf_thumb'] = None
 
     data['status_message'] = make_pdf_status_message(meta)
-
-    data['timeline'] = make_timeline_data(meta, "toc", lang)
 
     # associated documents
     explanatory_notes = []


### PR DESCRIPTION
## Summary

Implements [docs/adr/2026-05-18-timeline-enacted-made-visibility.md](docs/adr/2026-05-18-timeline-enacted-made-visibility.md). The UX team wants to experiment with treating the enacted/made version as qualitatively different from dated versions on the timeline — it represents the text at enactment, which may never have been in force and may never have been the law, so presenting it alongside amendment dates can mislead users.

New rules:

| Scenario | Timeline visible? | Enacted/made on it? |
|---|---|---|
| Enacted/made is the **only** version | Yes | Yes, as `current` |
| Multiple versions, viewing enacted/made | **No** | N/A |
| Multiple versions, viewing any other version | Yes | **No** |

**Invariant:** the user never sees a timeline that omits the version they are currently viewing.

The timeline is also removed entirely from Table of Contents pages — the UX team's view is that the ToC is a navigation surface, not a reading surface, so version context belongs only on document and fragment views.

## Data model change

`TimelineData` collapses from three buckets (`original` / `historical` / `current`) to two (`entries` / `current`). Under the new rules, the enacted/made version either *is* the current entry (when it's the sole version) or it's absent from the timeline entirely — it never coexists with other entries, so a dedicated `original` slot is dead weight. Removing it now, while the semantics are actively being reworked, is cheaper than carrying a vestigial field.

## Deferred (intentionally not in this PR)

One follow-up exception is anticipated: **restoring the enacted/made version to the timeline for documents from before the digital base date.** For these old, pre-electronic documents, the first revised version is a consolidation of decades of pre-digital amendments rather than a textually faithful representation of any single prior state. In that context the enacted/made version represents a genuinely distinct moment in time, so suppressing it from the timeline (as this PR does uniformly) would lose meaningful information.

The new `entries` list structure is designed to accommodate this case later — the enacted/made entry will simply appear as a regular entry alongside the dated versions, rather than needing the dedicated `original` slot that the old data model carried. Designer mock-ups in `_mvp-files_v6/mvp/scenarios/base-date-*` cover the visual treatment; that work is out of scope here.

## How users reach the enacted/made version when it's hidden

Not addressed by this PR. The UX team will provide a separate navigation mechanism (likely a link elsewhere on the page).

## Test plan

- [x] Unit tests in \`lgu2/tests/util/test_timeline.py\` cover the four ADR scenarios: single enacted, multi viewing enacted (returns \`None\`), multi viewing dated (enacted excluded), two-version (enacted + one date).
- [x] View regression in \`lgu2/tests/test_document_views.py\` asserts \`class=\"timeline\"\` is absent from ToC responses.
- [x] Full test suite passes (266 tests).
- [x] Manual check: visit a multi-version document at its enacted/made URL — confirm no timeline section renders.
- [x] Manual check: visit a single-version (enacted-only) document — confirm timeline renders with enacted as the sole entry.
- [x] Manual check: visit a ToC page — confirm no timeline section.
- [x] Manual check: the PIT search summary no longer says "or choose from the versions on the timeline" on enacted/made pages of multi-version documents.
