### PR TITLE
Fix not-found 404 handling and Cymraeg toggle link

### DIFF
--- a/lgu2/api/contents.py
+++ b/lgu2/api/contents.py
@@ -49,8 +49,7 @@ def get_toc(
 ) -> Optional[TableOfContents]:
     url = _make_url(type, year, number, version)
     toc = server.get_json(url, language)
-    # Check if response is a "404" document-not-found type
-    if toc.get("status") == 404 and toc.get("error") == "Document Not Found":
+    if "error" in toc:
         return None
     CommonMetadata.convert_dates(toc["meta"])
     return toc

--- a/lgu2/api/document.py
+++ b/lgu2/api/document.py
@@ -117,6 +117,8 @@ def get_document(
 ) -> Union[Document, AssociatedDocument]:
     url = _make_url(type, year, number, version)
     doc = server.get_json(url, language)
+    if "error" in doc:
+        return doc
     if type == "ukia":
         AssociatedDocumentMeta.convert_dates(doc["meta"])
     else:

--- a/lgu2/api/fragment.py
+++ b/lgu2/api/fragment.py
@@ -86,6 +86,8 @@ def get(
 ) -> Fragment:
     url = _make_url(type, year, number, section, version)
     frag = server.get_json(url, language)
+    if "error" in frag:
+        return frag
     FragmentMetadata.convert_dates(frag["meta"])
     return frag
 

--- a/lgu2/templates/new_theme/common/header.html
+++ b/lgu2/templates/new_theme/common/header.html
@@ -32,7 +32,7 @@
 						<nav aria-labelledby="changeLanguage" class="hdr-lang">
 							<h3 id="changeLanguage">Change language</h3>
                             <ul>
-                                <li><a href="/cy" lang="cy">Cymraeg</a></li>
+                                <li><a href="/cy/" lang="cy">Cymraeg</a></li>
                                 <li><a href="/" aria-current="page"><span>Language set to </span>English</a></li>
                             </ul>
                         </nav>

--- a/lgu2/tests/api/test_not_found.py
+++ b/lgu2/tests/api/test_not_found.py
@@ -1,0 +1,46 @@
+"""Regression tests: API helpers must not crash when the upstream returns an
+error body (typically a 404 'Document Not Found'). Before these guards were
+added, the helpers blindly called `convert_dates(doc["meta"])` on the error
+body and raised KeyError, surfacing as a 500 to the user."""
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from lgu2.api import contents, document, fragment
+
+ERROR_BODY = {"status": 404, "error": "Document Not Found"}
+
+
+class GetDocumentNotFoundTests(SimpleTestCase):
+
+    @patch("lgu2.api.document.server.get_json")
+    def test_error_body_is_returned_as_is(self, mock_get_json):
+        mock_get_json.return_value = ERROR_BODY
+        # Cover both branches of the ukia / non-ukia type check.
+        for doc_type in ("ukpga", "ukia"):
+            with self.subTest(type=doc_type):
+                self.assertEqual(document.get_document(doc_type, 9999, 1), ERROR_BODY)
+
+
+class FragmentGetNotFoundTests(SimpleTestCase):
+
+    @patch("lgu2.api.fragment.server.get_json")
+    def test_error_body_is_returned_as_is(self, mock_get_json):
+        mock_get_json.return_value = ERROR_BODY
+        self.assertEqual(fragment.get("ukpga", 2000, 8, "section-99999"), ERROR_BODY)
+
+
+class GetTocNotFoundTests(SimpleTestCase):
+
+    @patch("lgu2.api.contents.server.get_json")
+    def test_returns_none_for_status_404_with_canonical_message(self, mock_get_json):
+        mock_get_json.return_value = ERROR_BODY
+        self.assertIsNone(contents.get_toc("ukpga", 9999, 1))
+
+    @patch("lgu2.api.contents.server.get_json")
+    def test_returns_none_for_any_error_body_shape(self, mock_get_json):
+        # The pre-fix guard only matched the exact canonical shape, so other
+        # error bodies fell through to convert_dates and 500'd.
+        mock_get_json.return_value = {"error": "anything else"}
+        self.assertIsNone(contents.get_toc("ukpga", 9999, 1))

--- a/lgu2/tests/test_document_views.py
+++ b/lgu2/tests/test_document_views.py
@@ -222,3 +222,40 @@ class TocViewTests(SimpleTestCase):
         self.assertNotContains(response, "Printer Version")
         self.assertNotContains(response, "received Royal Assent when it was enacted")
         self.assertNotContains(response, "Legislation text for the whole Act")
+
+
+# Regression: a not-found upstream response used to surface as a 500
+# (KeyError 'meta' in the API helper or the view). It must now render as 404.
+
+
+class DocumentNotFoundTests(SimpleTestCase):
+
+    @patch("lgu2.views.document.get_document")
+    def test_document_returns_404_for_error_body(self, mock_get_document):
+        mock_get_document.return_value = {"error": "Document Not Found"}
+        response = self.client.get(reverse("document", args=["ukpga", 9999, 1]))
+        self.assertEqual(response.status_code, 404)
+
+
+class FragmentNotFoundTests(SimpleTestCase):
+
+    @patch("lgu2.views.fragment.api.head")
+    @patch("lgu2.views.fragment.api.get")
+    def test_fragment_returns_404_for_error_body(self, mock_api_get, mock_api_head):
+        # head() is called for subprovision-redirect logic before api.get().
+        # 404 means "no redirect target", so the view proceeds to api.get().
+        mock_api_head.return_value = 404
+        mock_api_get.return_value = {"error": "Document Not Found"}
+        response = self.client.get(
+            reverse("fragment", args=["ukpga", 2000, 8, "section-99999"])
+        )
+        self.assertEqual(response.status_code, 404)
+
+
+class TocNotFoundTests(SimpleTestCase):
+
+    @patch("lgu2.views.toc.api.get_toc")
+    def test_toc_returns_404_when_api_returns_none(self, mock_get_toc):
+        mock_get_toc.return_value = None
+        response = self.client.get(reverse("toc", args=["ukpga", 9999, 1]))
+        self.assertEqual(response.status_code, 404)

--- a/lgu2/views/fragment.py
+++ b/lgu2/views/fragment.py
@@ -85,16 +85,17 @@ def fragment(  # noqa: C901
         return redirect
 
     data = api.get(type, year, number, section, version, lang)
+
+    if "error" in data:
+        template = loader.get_template("404.html")
+        return HttpResponseNotFound(template.render({}, request))
+
     # API should add None values to fragment requests
     # but they're current missing for intro and last section
     if "prev" not in data["meta"]:
         data["meta"]["prev"] = None
     if "next" not in data["meta"]:
         data["meta"]["next"] = None
-
-    if "error" in data:
-        template = loader.get_template("404.html")
-        return HttpResponseNotFound(template.render({}, request))
 
     meta = data["meta"]
 


### PR DESCRIPTION
## Summary

Two front-end fixes for 404 issues found during end-to-end testing of the live site.

### 1. Return 404 (not 500) for not-found documents, fragments, and TOCs

Mistyped/nonexistent URLs returned 500 instead of a friendly 404. The API helpers in `lgu2/api/{document,fragment,contents}.py` called `convert_dates(doc["meta"])` unconditionally, so an upstream 404 body (`{"error": "Document Not Found", ...}`) raised `KeyError` before the view's own error guard could run — the view-side guards were effectively dead code.

- Guard `convert_dates` with `if "error" in doc: return doc` in `document.py` and `fragment.py`.
- In `contents.py`, replace the too-narrow guard (which required the exact `{status: 404, error: "Document Not Found"}` shape) with a generic `if "error" in toc: return None`.
- In `views/fragment.py`, move the existing `if "error" in data:` guard ahead of the `data["meta"]` accesses that previously came before it.

Adds API-layer regression tests in `lgu2/tests/api/test_not_found.py` and view-layer 404 integration tests in `test_document_views.py`.

### 2. Fix Cymraeg language toggle 404

`lgu2/templates/new_theme/common/header.html` had `href="/cy"` (no trailing slash), which 404s. Added the slash so the link reaches the Welsh homepage. The link is still a constant (drops users on the Welsh homepage regardless of current page); restoring the path-preserving UX from the old `top_banner.html` needs a small helper that handles the double-prefix case correctly — deferred.

## Test plan

- [x] All 4 reported not-found URLs (`/ukpga/9999/1`, `/ukpga/2000/8/section-99999`, `/ukpga/2000/8/totally-bogus-xyz`, `/ukpga/2000/8/enacted/contents`) now return 404 (were 500).
- [x] Known-good URLs (`/ukpga/2000/8`, `/ukpga/2000/8/contents`, `/ukpga/2000/8/section/1`) still return 200.
- [x] Cymraeg header link renders `/cy/` on both English (`/`) and Welsh-prefixed (`/cy/ukpga/2024/1`) pages; `/cy/` returns 200.
- [x] 277 tests pass; black + flake8 clean.

## Follow-ups

- **Port the `/contributors` page** from the legacy live site (https://www.legislation.gov.uk/contributors). The link in the OGL footer block (`new_theme/common/footer.html:28`) currently 404s; the legacy page covers EUR-Lex / Westlaw / British History Online re-use terms and attribution requirements. Content-migration task, not a one-liner.
- **Push HTTP-status awareness into `server.get_json`**. This PR's per-call-site guards cover 3 of 12 `get_json` callers; the other 9 (browse, doc_types, documents, dates, effects, metadata) still have the same latent bug. A status-aware helper would also let us distinguish upstream 5xx from 404 (currently both surface as 404). Best bundled with the missing HTTP timeouts in the same module.
- **Path-preserving Welsh ↔ English link helper** (see the second commit message for details).