### PR TITLE
Drop deprecated fragment/prev/next reads; use fragmentInfo/prevInfo/nextInfo

### DIFF
--- a/lgu2/api/fragment.py
+++ b/lgu2/api/fragment.py
@@ -9,9 +9,6 @@ from .document import CommonMetadata, XmlPackage, package_xml
 
 
 class FragmentMetadata(CommonMetadata):
-    fragment: str  # deprecated
-    prev: Optional[str]  # deprecated
-    next: Optional[str]  # deprecated
     fragmentInfo: "Level"
     prevInfo: Optional["LabelledLink"]
     nextInfo: Optional["LabelledLink"]
@@ -34,7 +31,7 @@ class FragmentMetadata(CommonMetadata):
 class Level(TypedDict):
     element: str
     id: str  # the internal id, e.g., section-1
-    href: str  # the full id with slashes, e.g., ukpga/2024/1/section/1
+    href: str  # the relative fragment id, e.g., crossheading/final-provisions
     number: str
     title: str
     label: str

--- a/lgu2/tests/util/test_redirects.py
+++ b/lgu2/tests/util/test_redirects.py
@@ -1,0 +1,75 @@
+from django.test import SimpleTestCase
+from django.urls import reverse
+
+from lgu2.util.redirects import should_redirect
+
+
+def _fragment_meta(**overrides):
+    meta = {
+        "shortType": "ukpga",
+        "year": 2024,
+        "number": 1,
+        "status": "final",
+        "version": "2025-01-01",
+        "fragmentInfo": {"href": "section/5", "label": "Section 5"},
+    }
+    meta.update(overrides)
+    return meta
+
+
+class ShouldRedirectFragmentTests(SimpleTestCase):
+    """The fragment branch of should_redirect must carry the fragment's
+    section into the redirect target, sourced from ``fragmentInfo['href']``
+    (the replacement for the removed deprecated top-level ``fragment``)."""
+
+    def test_final_status_redirects_to_versioned_url_with_section(self):
+        response = should_redirect("fragment", "ukpga", None, None, _fragment_meta())
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.url,
+            reverse(
+                "fragment-version",
+                args=["ukpga", 2024, 1, "section/5", "2025-01-01"],
+            ),
+        )
+
+    def test_section_tracks_fragment_info_href(self):
+        # The redirect's section must follow fragmentInfo['href'] verbatim,
+        # including multi-segment hrefs — this is the contract that replaced
+        # the deprecated top-level ``fragment`` string.
+        meta = _fragment_meta(fragmentInfo={"href": "schedule/2/paragraph/3"})
+        response = should_redirect("fragment", "ukpga", None, None, meta)
+        self.assertEqual(
+            response.url,
+            reverse(
+                "fragment-version",
+                args=["ukpga", 2024, 1, "schedule/2/paragraph/3", "2025-01-01"],
+            ),
+        )
+
+    def test_section_carried_with_language(self):
+        response = should_redirect("fragment", "ukpga", None, "welsh", _fragment_meta())
+        self.assertEqual(
+            response.url,
+            reverse(
+                "fragment-version-lang",
+                args=["ukpga", 2024, 1, "section/5", "2025-01-01", "welsh"],
+            ),
+        )
+
+    def test_type_canonicalisation_redirects_current_with_section(self):
+        # Non-final, wrong requested type, no version -> redirect to the
+        # canonical type at the current version, still carrying the section.
+        meta = _fragment_meta(status="revised", shortType="uksi")
+        response = should_redirect("fragment", "ukpga", None, None, meta)
+        self.assertEqual(
+            response.url,
+            reverse("fragment", args=["uksi", 2024, 1, "section/5"]),
+        )
+
+    def test_versioned_request_on_canonical_type_does_not_redirect(self):
+        response = should_redirect(
+            "fragment", "ukpga", "2025-01-01", None, _fragment_meta()
+        )
+        self.assertIsNone(response)

--- a/lgu2/util/redirects.py
+++ b/lgu2/util/redirects.py
@@ -17,8 +17,8 @@ def should_redirect(
 
     # extra kwargs (for fragment redirects)
     extra_kwargs = {}
-    if target == "fragment" and "fragment" in meta:
-        extra_kwargs["section"] = meta["fragment"]
+    if target == "fragment" and "fragmentInfo" in meta:
+        extra_kwargs["section"] = meta["fragmentInfo"]["href"]
 
     if version is None and meta["status"] == "final":
         return redirect_version(

--- a/lgu2/views/fragment.py
+++ b/lgu2/views/fragment.py
@@ -91,13 +91,6 @@ def fragment(  # noqa: C901
 
     data = api.get(type, year, number, section, version, lang)
 
-    # API should add None values to fragment requests
-    # but they're current missing for intro and last section
-    if "prev" not in data["meta"]:
-        data["meta"]["prev"] = None
-    if "next" not in data["meta"]:
-        data["meta"]["next"] = None
-
     meta = data["meta"]
 
     rdrct = should_redirect("fragment", type, version, lang, meta)
@@ -105,14 +98,22 @@ def fragment(  # noqa: C901
         return rdrct
 
     data["meta"]["link"] = make_document_link(type, year, number, version, lang)
-    if data["meta"]["prevInfo"]:
-        data["meta"]["prev"] = make_fragment_link(
+    # ``prev``/``next`` are computed-URL context keys read by the template,
+    # derived from prevInfo/nextInfo (None when there is no neighbour).
+    data["meta"]["prev"] = (
+        make_fragment_link(
             type, year, number, data["meta"]["prevInfo"]["href"], version, lang
         )
-    if data["meta"]["nextInfo"]:
-        data["meta"]["next"] = make_fragment_link(
+        if data["meta"]["prevInfo"]
+        else None
+    )
+    data["meta"]["next"] = (
+        make_fragment_link(
             type, year, number, data["meta"]["nextInfo"]["href"], version, lang
         )
+        if data["meta"]["nextInfo"]
+        else None
+    )
 
     frag_info = data["meta"]["fragmentInfo"]
 
@@ -183,7 +184,7 @@ def fragment(  # noqa: C901
             "whole": make_document_link(type, year, number, version, lang),
             "body": (
                 None
-                if "fragment" in data["meta"] and data["meta"]["fragment"] == "body"
+                if data["meta"]["fragmentInfo"]["href"] == "body"
                 else make_fragment_link(type, year, number, "body", version, lang)
             ),
             "schedules": (


### PR DESCRIPTION
## What

Stops the Django front end reading the deprecated top-level `fragment`, `prev`, and `next` JSON fields on `/fragment` responses, so the Spring Boot API can delete them (they are `@Deprecated(forRemoval = true)`). The replacements — `fragmentInfo` (with `href`/`label`) and `prevInfo`/`nextInfo` (LabelledLink) — were already present in the API contract.

## Changes

- **`util/redirects.py`** — fragment redirects take their `section` from `meta["fragmentInfo"]["href"]` instead of the deprecated `meta["fragment"]`.
- **`views/fragment.py`** — the "body" self-link suppression now compares `fragmentInfo["href"] == "body"`; `prev`/`next` (already driven by `prevInfo`/`nextInfo`) are now computed in a single ternary each rather than a default-then-overwrite two-step.
- **`api/fragment.py`** — removed the three deprecated fields from the `FragmentMetadata` TypedDict and corrected the `Level.href` comment (it holds a relative id, e.g. `crossheading/final-provisions`, not a full path).
- **`tests/util/test_redirects.py`** *(new)* — 5 unit tests covering the previously-untested fragment branch of `should_redirect`, pinning that the redirect section is sourced from `fragmentInfo["href"]`.

`prev`/`next` were never read for their value (the view already overwrote them from `prevInfo`/`nextInfo`); only the `fragment` field had live reads, both migrated here.

## Testing

- Full suite: **301 tests pass** (was 296).
- `black --check` and `flake8` clean.

## Follow-up (separate, API repo)

Deploy this **before** deleting the fields in the API. Worth a quick spot-check against a live `/fragment` response that `fragmentInfo.href` equals the old `fragment` for a `body`/`intro`/`schedule` fragment (`prev`/`next` → `prevInfo`/`nextInfo` is a guaranteed swap; `fragment` → `fragmentInfo.href` is equal by convention).
