### PR TITLE
Fix LocaleMiddleware ordering; tidy LANGUAGES assignment

### DIFF
--- a/lgu2/settings.py
+++ b/lgu2/settings.py
@@ -44,13 +44,16 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",  # must stay first
     "lgu2.middleware.central_logging.CentralRequestLoggingMiddleware",  # to get accurate timing best place to be here
     "django.contrib.sessions.middleware.SessionMiddleware",
+    # LocaleMiddleware must sit after SessionMiddleware (it reads session data)
+    # and before CommonMiddleware (which needs the active language to resolve
+    # and redirect i18n_patterns URLs, e.g. APPEND_SLASH on a /cy/… path).
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django.middleware.locale.LocaleMiddleware",
-    "lgu2.middleware.robots_middleware.RobotsTagMiddleware",  # move below security
+    "lgu2.middleware.robots_middleware.RobotsTagMiddleware",
     "lgu2.middleware.upstream_errors.UpstreamErrorMiddleware",
 ]
 
@@ -150,7 +153,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en"
 
-LANGUAGES = LANGUAGES = (("en", _("English")), ("cy", _("Welsh")))
+LANGUAGES = (("en", _("English")), ("cy", _("Welsh")))
 
 TIME_ZONE = "UTC"
 


### PR DESCRIPTION
## What

- Move `LocaleMiddleware` to sit **after `SessionMiddleware` but before `CommonMiddleware`**, matching Django's [documented middleware ordering](https://docs.djangoproject.com/en/stable/ref/middleware/#middleware-ordering). It previously sat after `CommonMiddleware`.
- Collapse the redundant `LANGUAGES = LANGUAGES = (...)` chained assignment to a single assignment.

## Why

`CommonMiddleware` needs the active language to resolve and redirect `i18n_patterns` URLs (e.g. `APPEND_SLASH` on a `/cy/…` path). With `LocaleMiddleware` ordered after it, the language isn't activated in time for those redirects — a latent source of locale-redirect edge cases.

Language activation via the `/cy/` prefix already worked (LocaleMiddleware reads the path itself in `process_request`) and is unchanged by this move. `manage.py check` passes.

## Context

Came out of triaging the 2026-06-15 front-end E2E sweep. The broader Welsh-chrome observation from that sweep is **string coverage, not a design flaw** — the i18n mechanism (`i18n_patterns(prefix_default_language=False)` + `LocaleMiddleware` + a 96/106-string `cy` catalogue) is sound, so full Welsh chrome is deferred pending real translators. This PR is just the one structural nit found while auditing that wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)